### PR TITLE
task: provide admin username of Matrix instead of access_token - EXO-74992

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -37,22 +37,38 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.exoplatform.social</groupId>
+      <groupId>io.meeds.social</groupId>
       <artifactId>social-component-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.social</groupId>
+      <groupId>io.meeds.social</groupId>
       <artifactId>social-component-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.social</groupId>
+      <groupId>io.meeds.social</groupId>
       <artifactId>social-component-service</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/services/src/main/java/io/meeds/chat/ChatPortlet.java
+++ b/services/src/main/java/io/meeds/chat/ChatPortlet.java
@@ -1,0 +1,19 @@
+package io.meeds.chat;
+
+import org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import java.io.IOException;
+
+public class ChatPortlet extends GenericDispatchedViewPortlet {
+  private static final Log LOG                  = ExoLogger.getLogger(ChatPortlet.class);
+
+  @Override
+  protected void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
+    super.doView(request, response);
+  }
+}

--- a/services/src/main/java/io/meeds/chat/web/MatrixAuthJWTFilter.java
+++ b/services/src/main/java/io/meeds/chat/web/MatrixAuthJWTFilter.java
@@ -1,0 +1,56 @@
+package io.meeds.chat.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.exoplatform.addons.matrix.services.MatrixConstants;
+import org.exoplatform.addons.matrix.services.MatrixService;
+import org.exoplatform.web.filter.Filter;
+
+import java.io.IOException;
+
+public class MatrixAuthJWTFilter implements Filter {
+
+  private MatrixService matrixService;
+
+  public MatrixAuthJWTFilter(MatrixService matrixService) {
+    this.matrixService = matrixService;
+  }
+
+  /**
+   * Do filter.
+   *
+   * @param request the request
+   * @param response the response
+   * @param chain the chain
+   * @throws IOException Signals that an I/O exception has occurred.
+   * @throws ServletException the servlet exception
+   */
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+    if (httpRequest.getRemoteUser() != null) {
+      String sessionToken = matrixService.getJWTSessionToken(httpRequest.getRemoteUser());
+      Cookie cookie = new Cookie(MatrixConstants.MATRIX_JWT_COOKIE, sessionToken);
+      cookie.setPath("/");
+      cookie.setMaxAge(604800); // 7 days in seconds
+      cookie.setHttpOnly(true);
+      cookie.setSecure(request.isSecure());
+      httpResponse.addCookie(cookie);
+    } else {
+      Cookie oldCookie = new Cookie(MatrixConstants.MATRIX_JWT_COOKIE, "");
+      oldCookie.setMaxAge(0);
+      httpResponse.addCookie(oldCookie);
+    }
+
+    chain.doFilter(request, response);
+  }
+
+}
+

--- a/services/src/main/java/org/exoplatform/addons/matrix/jobs/CheckMatrixIDs.java
+++ b/services/src/main/java/org/exoplatform/addons/matrix/jobs/CheckMatrixIDs.java
@@ -3,6 +3,7 @@ package org.exoplatform.addons.matrix.jobs;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.addons.matrix.services.MatrixConstants;
 import org.exoplatform.addons.matrix.services.MatrixHttpClient;
+import org.exoplatform.addons.matrix.services.MatrixService;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
@@ -33,6 +34,7 @@ public class CheckMatrixIDs implements Job {
   public void execute(JobExecutionContext context) throws JobExecutionException {
     LOG.info("Start Checking users fro their Matrix IDs");
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+    MatrixService matrixService = CommonsUtils.getService(MatrixService.class);
     OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
 
     int checkedUsers = 0;
@@ -49,7 +51,7 @@ public class CheckMatrixIDs implements Job {
           Profile userProfile = userIdentity.getProfile();
           String userMatrixId = (String) userProfile.getProperty(MatrixConstants.USER_MATRIX_ID);
           if(StringUtils.isBlank(userMatrixId)) {
-            String matrixId = MatrixHttpClient.saveUserAccount(user, false);
+            String matrixId = MatrixHttpClient.saveUserAccount(user, false, matrixService.getMatrixAccessToken());
             userProfile.getProperties().put(USER_MATRIX_ID, matrixId);
             identityManager.updateProfile(userProfile);
           }

--- a/services/src/main/java/org/exoplatform/addons/matrix/listeners/IdentityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/matrix/listeners/IdentityListener.java
@@ -3,6 +3,7 @@ package org.exoplatform.addons.matrix.listeners;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.addons.matrix.services.MatrixConstants;
 import org.exoplatform.addons.matrix.services.MatrixHttpClient;
+import org.exoplatform.addons.matrix.services.MatrixService;
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
@@ -12,10 +13,13 @@ import org.exoplatform.social.core.storage.api.IdentityStorage;
 
 public class IdentityListener extends ProfileListenerPlugin {
 
-  private IdentityStorage identityStorage;
+  private final IdentityStorage identityStorage;
 
-  public IdentityListener(IdentityStorage identityStorage) {
+  private final MatrixService   matrixService;
+
+  public IdentityListener(IdentityStorage identityStorage, MatrixService matrixService) {
     this.identityStorage = identityStorage;
+    this.matrixService = matrixService;
   }
 
   @Override
@@ -27,10 +31,10 @@ public class IdentityListener extends ProfileListenerPlugin {
       if(!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
         mimeType = avatarFileItem.getFileInfo().getMimetype();
       }
-      String userAvatarUrl = MatrixHttpClient.uploadFile("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte());
+      String userAvatarUrl = MatrixHttpClient.uploadFile("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte(), matrixService.getMatrixAccessToken());
       String userMatrixID = (String) profile.getProperty(MatrixConstants.USER_MATRIX_ID);
       if(StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
-        MatrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl);
+        MatrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl, matrixService.getMatrixAccessToken());
       }
     }
   }

--- a/services/src/main/java/org/exoplatform/addons/matrix/listeners/MatrixUserLoginListener.java
+++ b/services/src/main/java/org/exoplatform/addons/matrix/listeners/MatrixUserLoginListener.java
@@ -2,6 +2,7 @@ package org.exoplatform.addons.matrix.listeners;
 
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.addons.matrix.services.MatrixHttpClient;
+import org.exoplatform.addons.matrix.services.MatrixService;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.listener.Asynchronous;
@@ -25,6 +26,8 @@ public class MatrixUserLoginListener extends Listener<ConversationRegistry, Conv
 
   private IdentityManager identityManager;
 
+  private MatrixService matrixService;
+
   private OrganizationService organizationService;
   public MatrixUserLoginListener(IdentityManager identityManager, OrganizationService organizationService) {
     this.identityManager = identityManager;
@@ -40,7 +43,7 @@ public class MatrixUserLoginListener extends Listener<ConversationRegistry, Conv
         String matrixUserId = (String) userProfile.getProperty(USER_MATRIX_ID);
         if(StringUtils.isBlank(matrixUserId)) {
           User user = organizationService.getUserHandler().findUserByName(userId);
-          String matrixId = MatrixHttpClient.saveUserAccount(user, false);
+          String matrixId = MatrixHttpClient.saveUserAccount(user, false, matrixService.getMatrixAccessToken());
           userProfile.getProperties().put(USER_MATRIX_ID, matrixId);
           identityManager.updateProfile(userProfile);
         }

--- a/services/src/main/java/org/exoplatform/addons/matrix/model/Events.java
+++ b/services/src/main/java/org/exoplatform/addons/matrix/model/Events.java
@@ -20,16 +20,16 @@ public class Events {
   public String toJson() {
     return """
             {
-                "m.room.name": 50,
-                "m.room.power_levels": 100,
-                "m.room.history_visibility": 100,
-                "m.room.canonical_alias": 50,
-                "m.room.avatar": 50,
-                "m.room.tombstone": 100,
-                "m.room.server_acl": 100,
-                "m.room.encryption": 100
+                "m.room.name": %s,
+                "m.room.power_levels": %s,
+                "m.room.history_visibility": %s,
+                "m.room.canonical_alias": %s,
+                "m.room.avatar": %s,
+                "m.room.tombstone": %s,
+                "m.room.server_acl": %s,
+                "m.room.encryption": %s
              }
-              """.formatted(this.getName(), this.getPowerLevels(), this.getHistoryVisibility(), this.getCanonicalAlias(), this.getAvatar(), this.getTombstone(), this.getServerAcl(), this.getEncryption());
+            """.formatted(this.getName(), this.getPowerLevels(), this.getHistoryVisibility(), this.getCanonicalAlias(), this.getAvatar(), this.getTombstone(), this.getServerAcl(), this.getEncryption());
   }
   public static Events fromJson(JsonValue jsonValue) {
     return new Events(jsonValue.getElement("m.room.name").getStringValue(),

--- a/services/src/main/java/org/exoplatform/addons/matrix/services/MatrixConstants.java
+++ b/services/src/main/java/org/exoplatform/addons/matrix/services/MatrixConstants.java
@@ -5,7 +5,13 @@ public class MatrixConstants {
   private MatrixConstants() {
   }
 
-  public static final String MATRIX_SERVER_URL             = "exo.matrix.server.url";
+  public static final String MATRIX_SERVER_URL             = "meeds.matrix.server.url";
+
+  public static final String MATRIX_ADMIN_USERNAME         = "meeds.matrix.user.name";
+
+  public static final String SERVER_NAME                   = "meeds.matrix.server.name";
+
+  public static final String SHARED_SECRET_REGISTRATION    = "meeds.matrix.shared_secret_registration";
 
   public static final String MATRIX_METADATA_TYPE          = "matrixSpaceIntegration";
 
@@ -16,17 +22,18 @@ public class MatrixConstants {
   public static final String MATRIX_SERVER_URL_IS_REQUIRED =
                                                            "The URL of the Matrix server is required, please provide it using System properties !";
 
-  public static final String MATRIX_ACCESS_TOKEN           = "exo.matrix.access_token";
+  public static final String MATRIX_ADMIN_USERNAME_IS_REQUIRED =
+                                                           "The username of the admin the Matrix server is required, please provide it using System properties !";
 
   public static final String BEARER                        = "Bearer ";
 
   public static final String AUTHORIZATION                 = "Authorization";
 
+  public static final String MATRIX_JWT_SECRET             = "meeds.matrix.jwt.secret";
+
+  public static final String MATRIX_JWT_COOKIE             = "matrix_jwt_token";
+
   public static final String CONTENT_TYPE                  = "Content-type";
-
-  public static final String SERVER_NAME                   = "exo.matrix.server.name";
-
-  public static final String SHARED_SECRET_REGISTRATION    = "exo.matrix.shared_secret_registration";
 
   public static final String USER_MATRIX_ID                = "matrixId";
 
@@ -37,8 +44,6 @@ public class MatrixConstants {
 
   // User roles on Matrix
   public static final String ADMIN_ROLE                    = "100";
-
-  public static final String MODERATOR_ROLE                = "50";
 
   public static final String SIMPLE_USER_ROLE              = "0";
 

--- a/services/src/test/java/MatrixUtilsTest.java
+++ b/services/src/test/java/MatrixUtilsTest.java
@@ -11,8 +11,7 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Random;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * This test class requires an available mattermost server
@@ -24,9 +23,10 @@ import static org.junit.Assert.fail;
 
 public class MatrixUtilsTest {
 
+  private String access_token = System.setProperty("exo.matrix.access_token", "syt_cm9vdA_HxkqWHDpGLbuvKoCYucM_1WlWyy");
+
   @Before
   public void setUp() {
-    System.setProperty("exo.matrix.access_token", "syt_cm9vdA_HxkqWHDpGLbuvKoCYucM_1WlWyy");
     System.setProperty("exo.matrix.server.url", "http://localhost:8008");
     System.setProperty("exo.matrix.shared_secret_registration", "4fzT.7xvkyp1EA-*bX#fzpVgOc_cb0y9z6*uOCUht1DO5ksad8");
     System.setProperty("exo.matrix.server.name", "matrix.exo.tn");
@@ -39,7 +39,7 @@ public class MatrixUtilsTest {
     user.setEmail("test@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    MatrixHttpClient.createUserAccount(user);
+    MatrixHttpClient.createUserAccount(user, access_token);
   }
 
   @Test
@@ -49,7 +49,7 @@ public class MatrixUtilsTest {
     user.setEmail("test@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    MatrixHttpClient.saveUserAccount(user, true);
+    MatrixHttpClient.saveUserAccount(user, true, access_token);
   }
 
   @Test
@@ -59,18 +59,18 @@ public class MatrixUtilsTest {
     user.setEmail("test" + randomKey + "@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    String username = MatrixHttpClient.saveUserAccount(user, true);
-    MatrixHttpClient.disableAccount(username, false);
+    String username = MatrixHttpClient.saveUserAccount(user, true, access_token);
+    MatrixHttpClient.disableAccount(username, false, access_token);
   }
 
   public void testRenameSpace() {
     String roomId = null;
     try {
-      roomId = MatrixHttpClient.createRoom("new room", "new room description");
+      roomId = MatrixHttpClient.createRoom("new room", "new room description", access_token);
     } catch (JsonException | IOException | InterruptedException e) {
 
     }
-    String eventId = MatrixHttpClient.renameRoom(roomId, "new room renamed" + new Date().getTime());
+    assertNotNull(MatrixHttpClient.renameRoom(roomId, "new room renamed" + new Date().getTime(), access_token));
   }
 
   public void testInviteUser() throws JsonException, IOException, InterruptedException {
@@ -79,9 +79,9 @@ public class MatrixUtilsTest {
     user.setEmail("test" + randomKey + "@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    String invitee = MatrixHttpClient.saveUserAccount(user, true);
-    String roomId = MatrixHttpClient.createRoom("Football game", "Description of Football team");
-    MatrixHttpClient.inviteUserToRoom(roomId, invitee, "Welcome to Football game room !");
+    String invitee = MatrixHttpClient.saveUserAccount(user, true, access_token);
+    String roomId = MatrixHttpClient.createRoom("Football game", "Description of Football team", access_token);
+    MatrixHttpClient.inviteUserToRoom(roomId, invitee, "Welcome to Football game room !", access_token);
   }
 
   /*
@@ -89,22 +89,22 @@ public class MatrixUtilsTest {
    */
   public void testKickUser() {
     String roomId = "!rYdqPkQhIzNWyVPDFX";
-    MatrixHttpClient.kickUserFromRoom(roomId, "@testuser1:matrix.exo.tn", "Talking too much!");
+    MatrixHttpClient.kickUserFromRoom(roomId, "@testuser1:matrix.exo.tn", "Talking too much!", access_token);
   }
 
   public void updateRoomSettings() {
     String roomId = "!rYdqPkQhIzNWyVPDFX";
-    MatrixRoomPermissions settings = MatrixHttpClient.getRoomSettings(roomId);
+    MatrixRoomPermissions settings = MatrixHttpClient.getRoomSettings(roomId, access_token);
     settings.setInvite("0");
-    String updateEventId = MatrixHttpClient.updateRoomSettings(roomId, settings);
+    String updateEventId = MatrixHttpClient.updateRoomSettings(roomId, settings, access_token);
   }
 
   public void updateRoomAvatar() {
     try {
       String roomId = "!HaTqHwWINwoSoIGfZx";
       byte[] resource = getClass().getClassLoader().getResourceAsStream("meeds.png").readAllBytes();
-      String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource);
-      boolean success = MatrixHttpClient.updateRoomAvatar(roomId, imageStored);
+      String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
+      boolean success = MatrixHttpClient.updateRoomAvatar(roomId, imageStored, access_token);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -114,10 +114,10 @@ public class MatrixUtilsTest {
       String roomId = "@root:matrix.exo.tn";
       int randomInt = new Random().nextInt(3);
       byte[] resource = getClass().getClassLoader().getResourceAsStream("avatar" + randomInt + ".png").readAllBytes();
-      String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource);
-      boolean success = MatrixHttpClient.updateUserAvatar(roomId, imageStored);
+      String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
+      assertTrue(MatrixHttpClient.updateUserAvatar(roomId, imageStored, access_token));
     } catch (IOException e) {
-      throw new RuntimeException(e);
+
     }
   }
 }

--- a/webapp/src/main/webapp/js/spaceCreatedListener.js
+++ b/webapp/src/main/webapp/js/spaceCreatedListener.js
@@ -1,6 +1,0 @@
-(function() {
-  document.addEventListener('space-created', space => {
-    console.log('space created');
-    console.log(space);
-  });
-});


### PR DESCRIPTION
The fix changes the way eXo and Matrix communicates. Instead of using the access_token of an admin and to avoid the step of its generation, we will just need the username of the account of a valid administrator on Matrix.
Then we will generate a JWT for that user to authenticate him and get the access_token that will be used later to send the requests to Matrix server.