### PR TITLE
feat: implement long polling to retrieve changes from Matrix - EXO-73482

### DIFF
--- a/webapp/src/main/resources/locale/portlet/matrix_en.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_en.properties
@@ -4,3 +4,4 @@ matrix.chat.discussions=Discussions
 matrix.chat.user.avatar.title=Avatar of {0}
 matrix.chat.space.avatar.title= Avatar of the space {0}
 matrix.chat.open=Open chat
+matrix.chat.no.rooms=You do not have discussions yet

--- a/webapp/src/main/resources/locale/portlet/matrix_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_fr.properties
@@ -4,3 +4,4 @@ matrix.chat.discussions=Discussions
 matrix.chat.user.avatar.title=Avatar de {0}
 matrix.chat.space.avatar.title=Avatar de l'espace {0}
 matrix.chat.open=Ouvrir le chat
+matrix.chat.no.rooms=Tu n'as pas encore de discussions

--- a/webapp/src/main/webapp/css/matrix.less
+++ b/webapp/src/main/webapp/css/matrix.less
@@ -2,19 +2,18 @@
 @import 'mixins.less';
 
 .chat-contact-avatar {
-  width: 35px;
-  height: 35px;
+  width: 45px;
+  height: 45px;
   background-size: cover;
   background-position: center;
   margin: auto;
+  border-radius: 50%;
 }
 
 .last-message-timestamp {
 }
 
 .chat-room-item {
-  height: 60px;
-  line-height: 60px;
   padding: 5px 20px;
   position: relative;
 
@@ -26,10 +25,17 @@
     width: 20px;
     height: 20px;
     line-height: 20px;
-    text-align: center
+    text-align: center;
+    margin-top: 20px;
   }
 }
 
 .contact-name {
   cursor: pointer;
+}
+#matrixChatButton {
+ .v-badge__badge{
+   height: 12px !important;
+   min-width: 12px !important;
+ }
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
@@ -1,23 +1,3 @@
-<!--
-
- This file is part of the Meeds project (https://meeds.io/).
-
- Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation; either
- version 3 of the License, or (at your option) any later version.
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public License
- along with this program; if not, write to the Free Software Foundation,
- Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
--->
 <template>
   <exo-drawer
     ref="drawer"
@@ -37,7 +17,7 @@
         class="d-flex light-grey-background-color fill-height">
         <div
           class="singlePageApplication pa-0 d-flex fill-height">
-          <matrix-chat-rooms :contacts="rooms"/>
+          <matrix-chat-rooms />
         </div>
       </div>
     </template>
@@ -46,10 +26,6 @@
 <script>
 export default {
   props: {
-    badge: {
-      type: Number,
-      default: () => 0,
-    },
     rooms: {
       type: Array,
       default: function() { return [];}
@@ -70,10 +46,11 @@ export default {
       }
     },
     expanded() {
-      console.log(` drawer is expanded ${expanded}`);
+      console.log(`drawer is expanded ${expanded}`);
     },
   },
   created() {
+    console.log('drawer started to appear')
     this.$root.$on('chat-loading-start', this.incrementLoading);
     this.$root.$on('chat-loading-end', this.decrementLoading);
   },

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
@@ -17,7 +17,7 @@
         class="d-flex light-grey-background-color fill-height">
         <div
           class="singlePageApplication pa-0 d-flex fill-height">
-          <matrix-chat-rooms />
+          <matrix-chat-rooms :rooms="rooms"/>
         </div>
       </div>
     </template>
@@ -50,7 +50,6 @@ export default {
     },
   },
   created() {
-    console.log('drawer started to appear')
     this.$root.$on('chat-loading-start', this.incrementLoading);
     this.$root.$on('chat-loading-end', this.decrementLoading);
   },

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -16,8 +16,8 @@
     <div class="last-message-timestamp flex-row align-end my-2">
       {{ getLastMessageTime(room) }}
     </div>
-    <div v-if="room.unreadTotal" class="unread-messages">
-      {{ room.unreadTotal }}
+    <div v-if="room.unreadMessages" class="unread-messages my-2">
+      {{ room.unreadMessages }}
     </div>
   </div>
 </template>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -6,14 +6,14 @@
         class="chat-contact-avatar">
       <i v-if="type=='user' && isEnabled" class="uiIconStatus"></i>
     </div>
-    <div class="contact-name overflow-hidden ps-3 flex-grow-1"
+    <div class="contact-name overflow-hidden ps-3 flex-grow-1 my-2"
          @click="openRoom">
       {{ room.name }}
         <div v-if="room.lastMessage" class="text-capitalize-first-letter text-subtitle text-truncate">
           {{ room.lastMessage }}
         </div>
     </div>
-    <div class="last-message-timestamp flex-row align-end">
+    <div class="last-message-timestamp flex-row align-end my-2">
       {{ getLastMessageTime(room) }}
     </div>
     <div v-if="room.unreadTotal" class="unread-messages">

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
@@ -20,30 +20,25 @@
 </template>
 <script>
   export default {
-    data: () => ({
-      rooms: []
-    }),
+    props: {
+      rooms: {
+        type: Array,
+        default: function() { return [];}
+      }
+    },
     watch : {
       rooms() {
         console.log(this.rooms);
       }
     },
     created() {
-      this.loadRooms();
-      document.addEventListener(this.$matrixService.MATRIX_ACTION_MESSAGE_RECEIVED, event => this.messageReceived(event));
+      document.addEventListener('matrix-message-received', event => this.messageReceived(event));
     },
     methods: {
-      loadRooms() {
-        this.$matrixService.loadChatRooms(localStorage.getItem('matrix_user_id')).then(matrixRoomsObject => {
-          this.rooms = matrixRoomsObject.rooms || [];
-          this.$root.$emit('chat-event-total-unread-updated', matrixRoomsObject.totalUnreadMessages)
-        });
-      },
       messageReceived(event) {
-        console.log('Message received');
-        console.log(event.roomId);
-        console.log(event.message);
-        console.log('End message received');
+        const updatedRoom = this.rooms.find(room => room.id === event.detail.roomId);
+        updatedRoom.unreadMessages += 1;
+        updatedRoom.lastMessage = event.detail.message;
       }
     }
   }

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
@@ -8,25 +8,42 @@
           :id="'room-'+i"
           :room="room" />
     </div>
-    <div v-else>
-      {{ $t('chat.no.discussions') }}
+    <div v-else class="d-flex full-height disabled-background align-center justify-center full-width">
+      <div class="noRoomsContent">
+        <v-icon class="mx-auto disabled--text mb-3" size="100">fas fa-comments</v-icon>
+        <p class="text-subtitle">{{ $t('matrix.chat.no.rooms') }}</p>
+      </div>
     </div>
+
 
   </div>
 </template>
 <script>
   export default {
     data: () => ({
-      rooms: Array
+      rooms: []
     }),
     watch : {
+      rooms() {
+        console.log(this.rooms);
+      }
     },
     created() {
       this.loadRooms();
+      document.addEventListener(this.$matrixService.MATRIX_ACTION_MESSAGE_RECEIVED, event => this.messageReceived(event));
     },
     methods: {
-      loadRooms () {
-        this.$matrixService.loadChatRooms(localStorage.getItem('matrix_user_id')).then(rooms => this.rooms = rooms);
+      loadRooms() {
+        this.$matrixService.loadChatRooms(localStorage.getItem('matrix_user_id')).then(matrixRoomsObject => {
+          this.rooms = matrixRoomsObject.rooms || [];
+          this.$root.$emit('chat-event-total-unread-updated', matrixRoomsObject.totalUnreadMessages)
+        });
+      },
+      messageReceived(event) {
+        console.log('Message received');
+        console.log(event.roomId);
+        console.log(event.message);
+        console.log('End message received');
       }
     }
   }

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -5,10 +5,19 @@
         <v-btn
             id="btnChatButtonNew"
             :title="$t('matrix.chat.button.tooltip')"
+            class="text-xs-center"
             @click="openDrawer"
             :color="color"
             icon>
-          <v-icon size="22" class="my-auto icon-default-color fas fa-comments" />
+            <v-badge
+              :value="totalUnreadMessages > 0"
+              :content="totalUnreadMessages"
+              max="5"
+              flat
+              color="var(--allPagesBadgePrimaryColor, #d32a2a)"
+              overlap>
+              <v-icon size="22" class="icon-default-color">fa-comments</v-icon>
+            </v-badge>
         </v-btn>
       </div>
       <matrix-chat-drawer
@@ -24,7 +33,8 @@
     },
     data: () => ({
       color: 'green',
-      open: false
+      open: false,
+      totalUnreadMessages: 0
     }),
     created() {
       const matrixInfos = localStorage.getItem('matrix_user_id');
@@ -46,6 +56,15 @@
           }
         });
       }
+      this.$root.$on('chat-event-total-unread-updated',e => {
+        this.totalUnreadMessages = e;
+      });
+      document.addEventListener('matrix-message-received', event => this.messageReceived(event));
+      this.$matrixService.longPollingSync();
+    },
+    beforeDestroy() {
+      this.$root.$off('chat-event-total-unread-updated',e => this.totalUnreadMessages = e);
+      document.removeEventListener('matrix-message-received', event => this.messageReceived(event));
     },
     watch: {
       open() {
@@ -66,6 +85,12 @@
       openDrawer() {
         this.$root.initialized = false;
         this.open = true;
+      },
+      messageReceived(event) {
+        console.log('Chat button: Message received');
+        console.log(event.roomId);
+        console.log(event.message);
+        console.log('Chat button: End message received');
       }
     }
   };

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -23,6 +23,7 @@
       <matrix-chat-drawer
         v-if="open"
         ref="drawer"
+        :rooms="rooms"
         @closed="open = false" />
     </div>
   </div>
@@ -34,7 +35,8 @@
     data: () => ({
       color: 'green',
       open: false,
-      totalUnreadMessages: 0
+      totalUnreadMessages: 0,
+      rooms: []
     }),
     created() {
       const matrixInfos = localStorage.getItem('matrix_user_id');
@@ -59,6 +61,7 @@
       this.$root.$on('chat-event-total-unread-updated',e => {
         this.totalUnreadMessages = e;
       });
+      this.loadRooms();
       document.addEventListener('matrix-message-received', event => this.messageReceived(event));
       this.$matrixService.longPollingSync();
     },
@@ -87,11 +90,14 @@
         this.open = true;
       },
       messageReceived(event) {
-        console.log('Chat button: Message received');
-        console.log(event.roomId);
-        console.log(event.message);
-        console.log('Chat button: End message received');
-      }
+        this.totalUnreadMessages ++;
+      },
+      loadRooms() {
+         this.$matrixService.loadChatRooms(localStorage.getItem('matrix_user_id')).then(matrixRoomsObject => {
+           this.rooms = matrixRoomsObject.rooms || [];
+           this.$root.$emit('chat-event-total-unread-updated', matrixRoomsObject.totalUnreadMessages)
+         });
+       },
     }
   };
 </script>

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -4,7 +4,10 @@ import * as chatConstants from './Constants.js';
 const MATRIX_SERVER_URL='http://localhost:8008';
 const JWT_COOKIE_NAME = 'matrix_jwt_token';
 const DEFAULT_ROOM_AVATAR = '/matrix/img/room-default.jpg';
-
+const MATRIX_SYNC_SINCE = 'matrix-sync-since';
+const MATRIX_SYNC_TIMEOUT = 30000;
+const MATRIX_EMPTY_FILTER = 0;
+const MATRIX_ACTION_MESSAGE_RECEIVED = 'matrix-message-received';
 
 
 export function checkAuthenticationTypes() {
@@ -49,6 +52,8 @@ export function authenticate() {
     throw new Error('Could not find the JWT token');
   }
 }
+
+// change this function and make it aAsync
 export function loadChatRooms(currentMemberId) {
   const filter = {
                     "room":{
@@ -62,8 +67,14 @@ export function loadChatRooms(currentMemberId) {
                     }
                   };
   return sync(filter).then(resp => {
-    console.log(resp.rooms);
-    return toRoomObject(resp.rooms.join, currentMemberId);
+    if (!resp || !resp.ok) {
+      throw new Error('Response code indicates a server error', resp);
+    } else {
+      return resp.json();
+    }
+  }).then(resp => {
+    localStorage.setItem(MATRIX_SYNC_SINCE, resp?.next_batch);
+      return toRoomObject(resp?.rooms?.join, currentMemberId);
   });
 }
 export function loadRoom(roomId) {
@@ -135,7 +146,6 @@ export function updateDMRoomsAccountData(matrixIDUser, matrixUserDMRooms) {
       },
       body: JSON.stringify(matrixUserDMRooms)
     }).then(resp => {
-      console.log(resp);
       if (!resp || !resp.ok) {
         throw new Error('Response code indicates a server error', resp);
       } else {
@@ -164,20 +174,35 @@ export function sync(filter, since, timeout) {
     headers: {
       'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
     }
-  }).then(resp => {
-    if (!resp || !resp.ok) {
-      throw new Error('Response code indicates a server error', resp);
-    } else {
-      return resp.json();
-    }
   });
 }
+
+export function processEvents(response) {
+  const updatedRooms = response?.rooms?.join;
+  if(updatedRooms) {
+    for (const roomId in response.rooms.join) {
+      const roomEvents = response.rooms.join[roomId].timeline?.events;
+      roomEvents.forEach(e => {
+        if(e.type === 'm.room.message') {
+          if(e.content.msgtype === 'm.text') {
+            console.log('event sent START');
+            document.dispatchEvent(new CustomEvent('matrix-message-received', {roomId: roomId, message: e.content.body}));
+            console.log('event sent END');
+          }
+        }
+      });
+    }
+  }
+}
+
 export function toRoomObject(rooms, currentMemberId) {
-  let myRooms = [];
+  let myRooms = {};
+  myRooms.rooms = [];
+  myRooms.totalUnreadMessages = 0;
   for (const property in rooms) {
     let roomItem = {};
     let members = [];
-    const roomEvents = rooms[property].timeline.events.length ? rooms[property].timeline.events : rooms[property].state.events;
+    const roomEvents = [...rooms[property].timeline.events, ...rooms[property].state.events];
     roomEvents.forEach(e => {
       if(e.type === 'm.room.topic'){
         roomItem.topic = e.content.topic;
@@ -190,11 +215,8 @@ export function toRoomObject(rooms, currentMemberId) {
         roomItem.avatarUrl = '/_matrix/media/v3/thumbnail/' + avatarUrl +'?width=32&height=32&method=crop&allow_redirect=true';
       }
       if(e.type === 'm.room.member'){
-        if(e.content.membership === 'invite' && e.content.is_direct) {
-          roomItem.isDirectChat = true;
-        }
         if(e.content.membership === 'join') {
-        if(!members.some(element => element.id == e.sender)) {
+          if(!members.some(element => element.id == e.sender)) {
             let member = {};
             member.id = e.sender;
             member.name = e.content.displayname;
@@ -202,12 +224,12 @@ export function toRoomObject(rooms, currentMemberId) {
           }
         }
       }
-      if(e.type === 'm.room.message') {
-        if(e.content.msgtype === 'm.text') {
+      if(e.type === 'm.room.message') {;
+        if(e.content.msgtype === 'm.text' && (!roomItem.updated || roomItem.updated <= e.origin_server_ts)) {
+          roomItem.updated = e.origin_server_ts;
           roomItem.lastMessage = e.content.body;
         }
       }
-      roomItem.updated = roomItem.updated >= e.origin_server_ts ? roomItem.updated : e.origin_server_ts;
     });
     roomItem.members = members;
 
@@ -217,8 +239,9 @@ export function toRoomObject(rooms, currentMemberId) {
     roomItem.isExternal = false;
     roomItem.isFavorite = false;
     roomItem.unreadTotal = rooms[property].unread_notifications.notification_count;
-    if(roomItem.isDirectChat && roomItem.members.length == 2) {
+    if(!roomItem.name && roomItem.members.length == 2) {
       roomItem.name = roomItem.members.filter(member => member.id !== matrixUserId)?.shift()?.name;
+      roomItem.isDirectChat = true;
     }
     if(roomItem.members == 1) {
       roomItem.name = 'Empty Room';
@@ -226,9 +249,11 @@ export function toRoomObject(rooms, currentMemberId) {
     if(!roomItem.avatarUrl) {
       roomItem.avatarUrl = DEFAULT_ROOM_AVATAR;
     }
-    myRooms.push(roomItem);
+    myRooms.totalUnreadMessages += roomItem.unreadTotal;
+    myRooms.rooms.push(roomItem);
   }
-  return myRooms.sort((roomOne, roomTwo) => roomOne.updated <= roomTwo.updated);
+  myRooms.rooms.sort((roomOne, roomTwo) => roomOne.updated <= roomTwo.updated);
+  return myRooms;
 }
 
 export function getRedirectURLOfRoom(roomId, serverName) {
@@ -279,4 +304,27 @@ export function openDMRoom(firstParticipant, secondParticipant, matrixServerName
   }).catch(e => {
     console.log(e)
   });
+}
+
+export async function longPollingSync() {
+  const since = localStorage.getItem(MATRIX_SYNC_SINCE) || '';
+  let response = await sync(MATRIX_EMPTY_FILTER, since, MATRIX_SYNC_TIMEOUT);
+
+  if (response.status == 502) {
+    // Status 502 is a connection timeout error, let's retry
+    await longPollingSync();
+  } else if (response.status != 200) {
+    console.error(response.statusText);
+    // Reconnect in five second
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    await longPollingSync();
+  } else {
+    // Get and show the message
+    let message = await response.json();
+    console.log(message);
+    processEvents(message);
+    localStorage.setItem(MATRIX_SYNC_SINCE, message.next_batch);
+    // call again to get the next batch of data
+    await longPollingSync();
+  }
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -186,7 +186,7 @@ export function processEvents(response) {
         if(e.type === 'm.room.message') {
           if(e.content.msgtype === 'm.text') {
             console.log('event sent START');
-            document.dispatchEvent(new CustomEvent('matrix-message-received', {roomId: roomId, message: e.content.body}));
+            document.dispatchEvent(new CustomEvent('matrix-message-received', { detail: {roomId: roomId, message: e.content.body}}));
             console.log('event sent END');
           }
         }
@@ -238,7 +238,7 @@ export function toRoomObject(rooms, currentMemberId) {
     roomItem.isEnabledUser = true;
     roomItem.isExternal = false;
     roomItem.isFavorite = false;
-    roomItem.unreadTotal = rooms[property].unread_notifications.notification_count;
+    roomItem.unreadMessages = rooms[property].unread_notifications.notification_count;
     if(!roomItem.name && roomItem.members.length == 2) {
       roomItem.name = roomItem.members.filter(member => member.id !== matrixUserId)?.shift()?.name;
       roomItem.isDirectChat = true;
@@ -249,7 +249,7 @@ export function toRoomObject(rooms, currentMemberId) {
     if(!roomItem.avatarUrl) {
       roomItem.avatarUrl = DEFAULT_ROOM_AVATAR;
     }
-    myRooms.totalUnreadMessages += roomItem.unreadTotal;
+    myRooms.totalUnreadMessages += roomItem.unreadMessages;
     myRooms.rooms.push(roomItem);
   }
   myRooms.rooms.sort((roomOne, roomTwo) => roomOne.updated <= roomTwo.updated);
@@ -321,7 +321,6 @@ export async function longPollingSync() {
   } else {
     // Get and show the message
     let message = await response.json();
-    console.log(message);
     processEvents(message);
     localStorage.setItem(MATRIX_SYNC_SINCE, message.next_batch);
     // call again to get the next batch of data


### PR DESCRIPTION
This fix will add long polling to have a permanent communication channel with the Matrix server and get the updates (new messages, new rooms joined, etc...)
It also adds the badge to notify about the total unread messages and the unread messages by room. 