### PR TITLE
fix: room manager should be the room's moderator on Matrix-EXO-72435

### DIFF
--- a/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
@@ -53,7 +53,7 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
           String matrixIdOfUser = matrixService.getMatrixIdForUser(manager);
           if(StringUtils.isNotBlank(matrixRoomId) && StringUtils.isNotBlank(matrixIdOfUser)) {
             matrixService.joinUserToRoom(matrixRoomId, matrixIdOfUser);
-            matrixService.makeUserAdminInRoom(matrixRoomId, matrixIdOfUser);
+            updateMemberRoleInSpace(space, matrixIdOfUser, MANAGER_ROLE);
             members.remove(manager);
           }
         }


### PR DESCRIPTION
When a space is created , the space creator should have the role Moderator on Matrix . The fix will provide the needed permissions when the space is created.