### PR TITLE
feat: enable matrix chat for a dedicated group - EXO-74673

### DIFF
--- a/services/src/main/java/io/meeds/chat/listeners/IdentityListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/IdentityListener.java
@@ -34,16 +34,18 @@ public class IdentityListener extends ProfileListenerPlugin {
   @Override
   public void avatarUpdated(ProfileLifeCycleEvent event) {
     Profile profile = event.getProfile();
-    FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
-    String mimeType = "image/jpg";
-    if (avatarFileItem != null && avatarFileItem.getFileInfo() != null) {
-      if(!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
-        mimeType = avatarFileItem.getFileInfo().getMimetype();
-      }
-      String userMatrixID = (String) profile.getProperty(MatrixConstants.USER_MATRIX_ID);
-      String userAvatarUrl = matrixService.uploadFileOnMatrix("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte());
-      if(StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
-        matrixService.updateUserAvatar(userMatrixID, userAvatarUrl);
+    String userMatrixID = (String) profile.getProperty(MatrixConstants.USER_MATRIX_ID);
+    if (StringUtils.isNotBlank(userMatrixID)) {
+      FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
+      String mimeType = "image/jpg";
+      if (avatarFileItem != null && avatarFileItem.getFileInfo() != null) {
+        if (!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
+          mimeType = avatarFileItem.getFileInfo().getMimetype();
+        }
+        String userAvatarUrl = matrixService.uploadFileOnMatrix("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte());
+        if (StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
+          matrixService.updateUserAvatar(userMatrixID, userAvatarUrl);
+        }
       }
     }
   }

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixUserListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixUserListener.java
@@ -3,7 +3,6 @@ package io.meeds.chat.listeners;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.service.utils.MatrixConstants;
-import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.service.MatrixService;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.services.organization.OrganizationService;
@@ -14,16 +13,17 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_RESTRICTED_USERS_GROUP;
 import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
 
 @Component
 public class MatrixUserListener extends UserEventListener {
 
   @Autowired
-  private IdentityManager identityManager;
+  private IdentityManager     identityManager;
 
   @Autowired
-  private MatrixService   matrixService;
+  private MatrixService       matrixService;
 
   @Autowired
   private OrganizationService organizationService;
@@ -35,10 +35,15 @@ public class MatrixUserListener extends UserEventListener {
 
   @Override
   public void postSave(User user, boolean isNew) throws Exception {
-    if(identityManager != null) {
+    String matrixRestrictedGroup = PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP);
+    if (StringUtils.isNotBlank(matrixRestrictedGroup) && !this.matrixService.isUserMemberOfGroup(user.getUserName(), matrixRestrictedGroup)) {
+      return;
+    }
+    if (identityManager != null) {
       Profile userProfile = identityManager.getProfile(identityManager.getOrCreateUserIdentity(user.getUserName()));
       String matrixId = matrixService.saveUserAccount(user, isNew, false);
-      if(StringUtils.isNotBlank(matrixId) && userProfile.getProperty(USER_MATRIX_ID) == null || StringUtils.isBlank(userProfile.getProperty(USER_MATRIX_ID).toString())) {
+      if (StringUtils.isNotBlank(matrixId) && userProfile.getProperty(USER_MATRIX_ID) == null
+          || StringUtils.isBlank(userProfile.getProperty(USER_MATRIX_ID).toString())) {
         userProfile.getProperties().put(USER_MATRIX_ID, matrixId);
         identityManager.updateProfile(userProfile);
       }
@@ -47,12 +52,18 @@ public class MatrixUserListener extends UserEventListener {
 
   @Override
   public void postSetEnabled(User user) throws Exception {
-    if(!user.isEnabled()) {
-      String matrixUsername = "@" + user.getUserName() + ":" + PropertyManager.getProperty(MatrixConstants.MATRIX_SERVER_NAME);
-      matrixService.disableAccount(matrixUsername);
-    } else {
-      matrixService.saveUserAccount(user, false, true);
+    if (identityManager != null) {
+      Profile userProfile = identityManager.getProfile(identityManager.getOrCreateUserIdentity(user.getUserName()));
+      String matrixId = (String) userProfile.getProperty(USER_MATRIX_ID);
+      if (StringUtils.isNotBlank(matrixId)) {
+        if (!user.isEnabled()) {
+          String matrixUsername =
+                                "@" + user.getUserName() + ":" + PropertyManager.getProperty(MatrixConstants.MATRIX_SERVER_NAME);
+          matrixService.disableAccount(matrixUsername);
+        } else {
+          matrixService.saveUserAccount(user, false, true);
+        }
+      }
     }
   }
-
 }

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixUserLoginListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixUserLoginListener.java
@@ -4,8 +4,10 @@ import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.service.MatrixService;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
@@ -15,11 +17,13 @@ import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.security.ConversationRegistry;
 import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_RESTRICTED_USERS_GROUP;
 import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
 
 @Component
@@ -39,6 +43,9 @@ public class MatrixUserLoginListener extends Listener<ConversationRegistry, Conv
   @Autowired
   private ListenerService     listenerService;
 
+  @Autowired
+  private UserACL             userACL;
+
   @PostConstruct
   public void init() {
     listenerService.addListener("exo.core.security.ConversationRegistry.register", this);
@@ -47,11 +54,16 @@ public class MatrixUserLoginListener extends Listener<ConversationRegistry, Conv
   public void onEvent(Event<ConversationRegistry, ConversationState> event) {
     RequestLifeCycle.begin(PortalContainer.getInstance());
     String userId = event.getData().getIdentity().getUserId();
+    Identity connectedUserIdentity = event.getData().getIdentity();
+    String matrixRestrictedGroup = PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP);
+    if (StringUtils.isNotBlank(matrixRestrictedGroup) && !userACL.isUserInGroup(connectedUserIdentity, matrixRestrictedGroup)) {
+      return;
+    }
     try {
-      if(identityManager != null) {
+      if (identityManager != null) {
         Profile userProfile = identityManager.getProfile(identityManager.getOrCreateUserIdentity(userId));
         String matrixUserId = (String) userProfile.getProperty(USER_MATRIX_ID);
-        if(StringUtils.isBlank(matrixUserId)) {
+        if (StringUtils.isBlank(matrixUserId)) {
           User user = organizationService.getUserHandler().findUserByName(userId);
           String matrixId = matrixService.saveUserAccount(user, true, false);
           userProfile.getProperties().put(USER_MATRIX_ID, matrixId);

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -10,10 +10,13 @@ import io.meeds.chat.storage.MatrixRoomStorage;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.PropertyManager;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
@@ -26,6 +29,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -34,16 +38,18 @@ import static io.meeds.chat.service.utils.MatrixConstants.*;
 @Service
 public class MatrixService {
 
-  private static final Log LOG = ExoLogger.getLogger(MatrixService.class);
+  private static final Log    LOG = ExoLogger.getLogger(MatrixService.class);
 
   @Autowired
-  private MatrixRoomStorage matrixRoomStorage;
+  private MatrixRoomStorage   matrixRoomStorage;
 
   @Autowired
-  private IdentityManager  identityManager;
+  private IdentityManager     identityManager;
 
+  @Autowired
+  private OrganizationService organizationService;
 
-  private String           matrixAccessToken;
+  private String              matrixAccessToken;
 
   @PostConstruct
   public void init() {
@@ -51,7 +57,7 @@ public class MatrixService {
   }
 
   private String getMatrixAccessToken() {
-    if(StringUtils.isBlank(this.matrixAccessToken)) {
+    if (StringUtils.isBlank(this.matrixAccessToken)) {
       try {
         String jwtAccessToken = this.getJWTSessionToken(PropertyManager.getProperty(MATRIX_ADMIN_USERNAME));
         this.matrixAccessToken = MatrixHttpClient.getAdminAccessToken(jwtAccessToken);
@@ -64,6 +70,7 @@ public class MatrixService {
 
   /**
    * Returns the ID of the room linked to a space
+   * 
    * @param space
    * @return the roomId linked to the space
    */
@@ -73,6 +80,7 @@ public class MatrixService {
 
   /**
    * Returns the ID of the room linked to a space
+   * 
    * @param roomId the Matrix room ID
    * @return the roomId linked to the space
    */
@@ -83,7 +91,7 @@ public class MatrixService {
   /**
    * records the matrix ID of the room linked top the space
    *
-   * @param space  the Space
+   * @param space the Space
    * @param roomId the ID of the matrix room
    * @return the room ID
    */
@@ -93,6 +101,7 @@ public class MatrixService {
 
   /**
    * Creates a room for predefined space
+   * 
    * @param space the space
    * @return String representing the room id
    * @throws JsonException
@@ -107,13 +116,14 @@ public class MatrixService {
 
   /**
    * Get the matrix ID of a defined user
+   * 
    * @param userName of the user
    * @return the matrix ID
    */
   public String getMatrixIdForUser(String userName) {
     Identity newMember = identityManager.getOrCreateUserIdentity(userName);
     Profile newMemberProfile = newMember.getProfile();
-    if(StringUtils.isNotBlank((String) newMemberProfile.getProperty(USER_MATRIX_ID))) {
+    if (StringUtils.isNotBlank((String) newMemberProfile.getProperty(USER_MATRIX_ID))) {
       return newMemberProfile.getProperty(USER_MATRIX_ID).toString();
     }
     return null;
@@ -121,20 +131,22 @@ public class MatrixService {
 
   /**
    * Returns the JWT for user authentication
+   * 
    * @param userNameOnMatrix the username of the current user
    * @return String
    */
   public String getJWTSessionToken(String userNameOnMatrix) {
     return Jwts.builder()
-            .setSubject(userNameOnMatrix)
-            .signWith(Keys.hmacShaKeyFor(PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes()))
-            .setExpiration(Date.from(LocalDate.now().plusDays(7).atStartOfDay(ZoneId.systemDefault()).toInstant()))
-            .compact();
+               .setSubject(userNameOnMatrix)
+               .signWith(Keys.hmacShaKeyFor(PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes()))
+               .setExpiration(Date.from(LocalDate.now().plusDays(7).atStartOfDay(ZoneId.systemDefault()).toInstant()))
+               .compact();
 
   }
 
   /**
    * Saves a new user on Matrix
+   * 
    * @param user the user to create on Matrix
    * @param isNew boolean if the user is new, then true
    * @return String the matrix user ID
@@ -202,21 +214,32 @@ public class MatrixService {
   public DirectMessagingRoom createDirectMessagingRoom(DirectMessagingRoom directMessagingRoom) throws ObjectAlreadyExistsException {
     String firstParticipant = directMessagingRoom.getFirstParticipant();
     String secondParticipant = directMessagingRoom.getSecondParticipant();
-    if(StringUtils.isBlank(firstParticipant) || StringUtils.isBlank(secondParticipant)) {
+    if (StringUtils.isBlank(firstParticipant) || StringUtils.isBlank(secondParticipant)) {
       throw new IllegalArgumentException("The ids of the room participants should not be null");
     }
-    if (identityManager.getOrCreateUserIdentity(directMessagingRoom.getFirstParticipant()) == null || identityManager.getOrCreateUserIdentity(directMessagingRoom.getSecondParticipant()) == null) {
+    if (identityManager.getOrCreateUserIdentity(directMessagingRoom.getFirstParticipant()) == null
+        || identityManager.getOrCreateUserIdentity(directMessagingRoom.getSecondParticipant()) == null) {
       throw new IllegalArgumentException("The ids of the room participants should be valid user identity ids");
     }
     DirectMessagingRoom matrixRoom = matrixRoomStorage.getDirectMessagingRoom(firstParticipant, secondParticipant);
-    if(matrixRoom == null) {
-      return matrixRoomStorage.saveDirectMessagingRoom(directMessagingRoom.getFirstParticipant(), directMessagingRoom.getSecondParticipant(), directMessagingRoom.getRoomId());
+    if (matrixRoom == null) {
+      return matrixRoomStorage.saveDirectMessagingRoom(directMessagingRoom.getFirstParticipant(),
+                                                       directMessagingRoom.getSecondParticipant(),
+                                                       directMessagingRoom.getRoomId());
     } else {
-      throw new ObjectAlreadyExistsException("A direct messaging room is already created for the users %s and %s".formatted(firstParticipant, secondParticipant));
+      throw new ObjectAlreadyExistsException("A direct messaging room is already created for the users %s and %s".formatted(firstParticipant,
+                                                                                                                            secondParticipant));
     }
   }
 
   public List<DirectMessagingRoom> getMatrixDMRoomsOfUser(String user) {
     return matrixRoomStorage.getMatrixDMRoomsOfUser(user);
+  }
+
+  public boolean isUserMemberOfGroup(String userName, String groupId) throws Exception {
+    this.organizationService = CommonsUtils.getOrganizationService();
+    Collection<Membership> userMemberships = this.organizationService.getMembershipHandler()
+                                                                     .findMembershipsByUserAndGroup(userName, groupId);
+    return !userMemberships.isEmpty();
   }
 }

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixConstants.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixConstants.java
@@ -13,6 +13,8 @@ public class MatrixConstants {
 
   public static final String MATRIX_SERVER_NAME                = "meeds.matrix.server.name";
 
+  public static final String MATRIX_RESTRICTED_USERS_GROUP     = "meeds.matrix.restricted.users.groupId";
+
   public static final String SHARED_SECRET_REGISTRATION        = "meeds.matrix.shared_secret_registration";
 
   public static final String MATRIX_SERVER_URL_IS_REQUIRED     =

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -2,6 +2,7 @@ package io.meeds.chat.service.utils;
 
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
+import org.apache.commons.codec.language.MatchRatingApproachEncoder;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import org.exoplatform.commons.utils.PropertyManager;
@@ -20,9 +21,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.util.ArrayList;
 
 import static io.meeds.chat.service.utils.MatrixConstants.*;
+import static java.lang.Character.toLowerCase;
 
 public class MatrixHttpClient {
   private static final Log LOG = ExoLogger.getLogger(MatrixHttpClient.class.toString());
@@ -232,7 +235,7 @@ public class MatrixHttpClient {
            "admin": false,
            "mac": "%s"
           }
-        """.formatted(nonce, user.getUserName(), user.getDisplayName(), user.getUserName(), hmac);
+        """.formatted(nonce, cleanMatrixUsername(user.getUserName()), user.getDisplayName(), user.getUserName(), hmac);
 
     try {
       HttpResponse<String> response = sendHttpPostRequest(url, token, payload);
@@ -261,7 +264,7 @@ public class MatrixHttpClient {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
 
-    String fullMatrixUserId = "@%s:%s".formatted(matrixUserId, PropertyManager.getProperty(MATRIX_SERVER_NAME));
+    String fullMatrixUserId = "@%s:%s".formatted(cleanMatrixUsername(matrixUserId), PropertyManager.getProperty(MATRIX_SERVER_NAME));
     String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_synapse/admin/v2/users/" + fullMatrixUserId;
 
     String payload;
@@ -802,5 +805,23 @@ public class MatrixHttpClient {
       return false;
     }
 
+  }
+
+  public static String cleanMatrixUsername(String userName) {
+    String matrixAllowedCharacters = "_-./=+";
+    StringBuilder formattedMatrixUserId = new StringBuilder();
+    if (StringUtils.isNotBlank(userName)) {
+      // remove accents if exists
+      String normalizedUserName = Normalizer.normalize(userName, Normalizer.Form.NFKD).replaceAll("\\p{M}", "");
+      for (int i = 0; i < normalizedUserName.length(); ++i) {
+        final int codePoint = normalizedUserName.codePointAt(i);
+        if (Character.isAlphabetic(codePoint) || Character.isDigit(codePoint) || matrixAllowedCharacters.indexOf(normalizedUserName.charAt(i)) >= 0) {
+          formattedMatrixUserId.append(toLowerCase(normalizedUserName.charAt(i)));// Matrix usernames should be lowercased
+        } else {
+          formattedMatrixUserId.append("-");
+        }
+      }
+    }
+    return formattedMatrixUserId.toString();
   }
 }

--- a/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
@@ -20,6 +21,7 @@ import org.exoplatform.social.core.space.SpaceFilter;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
+import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_RESTRICTED_USERS_GROUP;
 import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
 
 public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
@@ -36,8 +38,10 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
 
   private int              LOADED_USERS_COUNT = 3;
 
-
-  public MatrixRoomAndAccountsUpgradePlugin(InitParams initParams, SpaceService spaceService, MatrixService matrixService, IdentityManager identityManager) {
+  public MatrixRoomAndAccountsUpgradePlugin(InitParams initParams,
+                                            SpaceService spaceService,
+                                            MatrixService matrixService,
+                                            IdentityManager identityManager) {
     super(initParams);
     this.spaceService = spaceService;
     this.matrixService = matrixService;
@@ -65,7 +69,7 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
       int loadedSpaces = 0;
       while (loadedSpaces < spacesCount) {
         int actualSpacesToLoadCount =
-                loadedSpaces + SPACES_THRESHOLD < spacesCount ? SPACES_THRESHOLD : spacesCount - loadedSpaces;
+                                    loadedSpaces + SPACES_THRESHOLD < spacesCount ? SPACES_THRESHOLD : spacesCount - loadedSpaces;
         Space[] spacesToMigrate = spaces.load(loadedSpaces, actualSpacesToLoadCount);
         for (Space space : spacesToMigrate) {
           String roomId = matrixService.getRoomBySpace(space);
@@ -73,10 +77,11 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
             try {
               roomId = this.matrixService.createMatrixRoomForSpace(space);
               matrixService.createMatrixRoom(space, roomId);
-              for(String member : space.getMembers()) {
+              for (String member : space.getMembers()) {
                 Identity memberIdentity = identityManager.getOrCreateUserIdentity(member);
-                if(memberIdentity != null && StringUtils.isNotBlank((String) memberIdentity.getProfile().getProperty(MatrixConstants.USER_MATRIX_ID))) {
-                  String matrixIdOfUser = (String) memberIdentity.getProfile().getProperty(MatrixConstants.USER_MATRIX_ID);
+                if (memberIdentity != null
+                    && StringUtils.isNotBlank((String) memberIdentity.getProfile().getProperty(USER_MATRIX_ID))) {
+                  String matrixIdOfUser = (String) memberIdentity.getProfile().getProperty(USER_MATRIX_ID);
                   matrixService.joinUserToRoom(roomId, matrixIdOfUser);
                 }
               }
@@ -96,11 +101,11 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
       throw new RuntimeException("Error while retrieving spaces", e);
     }
     LOG.info("Summary :: create Matrix rooms for spaces, {} created rooms for {} spaces, {} ignored spaces, {} rooms failed to be created !",
-            successfullyMigratedSpaces,
-            spacesCount,
-            ignoredSpaces,
-            failedToMigrateSpaces);
-    if(failedToMigrateSpaces > 0) {
+             successfullyMigratedSpaces,
+             spacesCount,
+             ignoredSpaces,
+             failedToMigrateSpaces);
+    if (failedToMigrateSpaces > 0) {
       throw new RuntimeException("Some spaces were not upgraded!");
     }
     LOG.info("End:: create Matrix rooms for spaces in {}", System.currentTimeMillis() - startupTime);
@@ -108,15 +113,7 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
 
   @Override
   public boolean shouldProceedToUpgrade(String newVersion, String previousVersion) {
-    if (!this.isEnabled()) {
-      return false;
-    }
-    try {
-      return spaceService.getAllSpacesByFilter(new SpaceFilter()).getSize() > matrixService.getAllLinkedRooms();
-    } catch (Exception e) {
-      LOG.debug("Could not get the number of spaces", e);
-      return false;
-    }
+    return this.isEnabled();
   }
 
   private void synchronizeUsers() {
@@ -129,18 +126,36 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
     int checkedUsers = 0;
     int usersCount = 0;
 
+    ListAccess<User> users = null;
     RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
     try {
-      ListAccess<User> users = organizationService.getUserHandler().findAllUsers();
+      if (StringUtils.isNotBlank(PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP))) {
+        users =
+              organizationService.getUserHandler().findUsersByGroupId(PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP));
+      } else {
+        users = organizationService.getUserHandler().findAllUsers();
+      }
       usersCount = users.getSize();
-      while(checkedUsers < usersCount) {
+    } catch (Exception e) {
+      LOG.error("Error while checking users", e);
+    } finally {
+      RequestLifeCycle.end();
+    }
+
+    if (usersCount == 0) {
+      throw new IllegalStateException("No users to migrate, please check the value of the property matrix.restricted.users.groupId or remove it to select all users.");
+    }
+
+    RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
+    try {
+      while (checkedUsers < usersCount) {
         int usersToCheck = usersCount > checkedUsers + LOADED_USERS_COUNT ? LOADED_USERS_COUNT : (usersCount - checkedUsers);
         User[] usersArray = users.load(checkedUsers, usersToCheck);
         for (User user : usersArray) {
           Identity userIdentity = identityManager.getOrCreateUserIdentity(user.getUserName());
           Profile userProfile = userIdentity.getProfile();
-          String userMatrixId = (String) userProfile.getProperty(MatrixConstants.USER_MATRIX_ID);
-          if(StringUtils.isBlank(userMatrixId)) {
+          String userMatrixId = (String) userProfile.getProperty(USER_MATRIX_ID);
+          if (StringUtils.isBlank(userMatrixId)) {
             String matrixId = matrixService.saveUserAccount(user, true, false);
             userProfile.getProperties().put(USER_MATRIX_ID, matrixId);
             identityManager.updateProfile(userProfile);
@@ -155,10 +170,10 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
       RequestLifeCycle.end();
     }
     LOG.info("Summary :: create Matrix accounts for {} users, {} users were checked with their Matrix accounts, {} accounts failed to be created !",
-            checkedUsers,
-            usersCount,
-            usersCount - checkedUsers);
-    if(usersCount - checkedUsers > 0) {
+             checkedUsers,
+             usersCount,
+             usersCount - checkedUsers);
+    if (usersCount - checkedUsers > 0) {
       throw new RuntimeException("Some user accounts were not synchronized with Matrix!");
     }
     LOG.info("End:: Check users for their Matrix IDs", System.currentTimeMillis() - startupTime);

--- a/services/src/test/java/MatrixUtilsTest.java
+++ b/services/src/test/java/MatrixUtilsTest.java
@@ -4,6 +4,7 @@ import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.idm.UserImpl;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Date;
@@ -109,7 +110,16 @@ public class MatrixUtilsTest {
       String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
       assertTrue(MatrixHttpClient.updateUserAvatar(roomId, imageStored, access_token));
     } catch (IOException e) {
+      fail();
+    }
+  }
 
+  @Test
+  public void testCleanMatrixUsername() {
+    String[] usernames = new String[] {"Samueâl", "fre@d", "Shazia", "gorkef/", "²&é\"'(-è_çà)=²1234567890°+'azertyuiopqsdfghjklmù*^$wxcvbn,;:!?./§%µ¨£<>²&~#{[|`\\^@]}"};
+    for(String username: usernames) {
+      String result = MatrixHttpClient.cleanMatrixUsername(username);
+      assertNotNull(result);
     }
   }
 }

--- a/webapp/src/main/webapp/WEB-INF/jsp/matrix.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/matrix.jsp
@@ -1,5 +1,13 @@
 <%@page import="org.exoplatform.commons.utils.PropertyManager"%>
-
+<%@page import="io.meeds.chat.service.MatrixService"%>
+<%@page import="io.meeds.chat.service.utils.MatrixConstants"%>
+<%@page import="org.apache.commons.lang3.StringUtils"%>
+<%@page import="org.exoplatform.commons.utils.CommonsUtils"%>
+<%
+String matrixRestrictedGroup = PropertyManager.getProperty(MatrixConstants.MATRIX_RESTRICTED_USERS_GROUP);
+MatrixService matrixService = CommonsUtils.getService(MatrixService.class);
+if (StringUtils.isBlank(matrixRestrictedGroup) || matrixService.isUserMemberOfGroup(user.getUserName(), matrixRestrictedGroup)) {
+%>
 <div class="VuetifyApp">
   <div data-app="true"
     class="v-application v-application--is-ltr theme--light"
@@ -12,3 +20,4 @@
     </script>
   </div>
 </div>
+<%}%>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
@@ -26,20 +26,5 @@
         default: function() { return [];}
       }
     },
-    watch : {
-      rooms() {
-        console.log(this.rooms);
-      }
-    },
-    created() {
-      document.addEventListener('matrix-message-received', event => this.messageReceived(event));
-    },
-    methods: {
-      messageReceived(event) {
-        const updatedRoom = this.rooms.find(room => room.id === event.detail.roomId);
-        updatedRoom.unreadMessages += 1;
-        updatedRoom.lastMessage = event.detail.message;
-      }
-    }
   }
 </script>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -62,8 +62,9 @@
         this.totalUnreadMessages = e;
       });
       this.loadRooms();
+      this.$matrixService.saveFilter().then(filterResponse => this.$matrixService.longPollingSync(filterResponse.filter_id));
       document.addEventListener('matrix-message-received', event => this.messageReceived(event));
-      this.$matrixService.longPollingSync();
+
     },
     beforeDestroy() {
       this.$root.$off('chat-event-total-unread-updated',e => this.totalUnreadMessages = e);
@@ -91,13 +92,16 @@
       },
       messageReceived(event) {
         this.totalUnreadMessages ++;
+        const updatedRoom = this.rooms.find(room => room.id === event.detail.roomId);
+        updatedRoom.unreadMessages += 1;
+        updatedRoom.lastMessage = event.detail.message;
       },
       loadRooms() {
-         this.$matrixService.loadChatRooms(localStorage.getItem('matrix_user_id')).then(matrixRoomsObject => {
-           this.rooms = matrixRoomsObject.rooms || [];
-           this.$root.$emit('chat-event-total-unread-updated', matrixRoomsObject.totalUnreadMessages)
-         });
-       },
+        this.$matrixService.loadChatRooms(localStorage.getItem('matrix_user_id')).then(matrixRoomsObject => {
+          this.rooms = matrixRoomsObject.rooms || [];
+          this.$root.$emit('chat-event-total-unread-updated', matrixRoomsObject.totalUnreadMessages)
+        });
+      },
     }
   };
 </script>

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -6,7 +6,6 @@ const JWT_COOKIE_NAME = 'matrix_jwt_token';
 const DEFAULT_ROOM_AVATAR = '/matrix/img/room-default.jpg';
 const MATRIX_SYNC_SINCE = 'matrix-sync-since';
 const MATRIX_SYNC_TIMEOUT = 30000;
-const MATRIX_EMPTY_FILTER = 0;
 const MATRIX_ACTION_MESSAGE_RECEIVED = 'matrix-message-received';
 
 
@@ -158,7 +157,11 @@ export function sync(filter, since, timeout) {
   const formData = new FormData();
 
   if(filter) {
-    formData.append('filter', JSON.stringify(filter));
+    if(!isNaN(parseFloat(filter))) {
+      formData.append('filter', Number(filter));
+    } else {
+      formData.append('filter', JSON.stringify(filter));
+    }
   } else {
     formData.append('filter', "0");
   }
@@ -306,9 +309,9 @@ export function openDMRoom(firstParticipant, secondParticipant, matrixServerName
   });
 }
 
-export async function longPollingSync() {
+export async function longPollingSync(matrixFilterId) {
   const since = localStorage.getItem(MATRIX_SYNC_SINCE) || '';
-  let response = await sync(MATRIX_EMPTY_FILTER, since, MATRIX_SYNC_TIMEOUT);
+  let response = await sync(matrixFilterId || '0', since, MATRIX_SYNC_TIMEOUT);
 
   if (response.status == 502) {
     // Status 502 is a connection timeout error, let's retry
@@ -326,4 +329,22 @@ export async function longPollingSync() {
     // call again to get the next batch of data
     await longPollingSync();
   }
+}
+
+export function saveFilter() {
+  const payload = {"room":{"timeline":{"unread_thread_notifications":true},"state":{"lazy_load_members":true}}};
+  const matrixUserId = localStorage.getItem("matrix_user_id");
+  return fetch(`/_matrix/client/v3/user/${matrixUserId}/filter`, {
+    method: 'POST',
+    headers: {
+     'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
+    },
+    body: JSON.stringify(payload)
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Save Filter : Response code indicates a server error', resp);
+    } else {
+      return resp.json();
+    }
+  });
 }


### PR DESCRIPTION
This fix will restrict the enabled users to a restricted group by adding the JVM property  **meeds.matrix.restricted.users.groupId** , for example **meeds.matrix.restricted.users.groupId=/spaces/communication**
It fixes also the initiation of the sync filter that retrieves the Matrix rooms and discussions. 
