### PR TITLE
fix: throw exception to interrupt upper layers excution - EXO-76242

### DIFF
--- a/services/src/main/java/io/meeds/chat/listeners/IdentityListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/IdentityListener.java
@@ -6,6 +6,8 @@ import io.meeds.chat.service.utils.MatrixConstants;
 import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.service.MatrixService;
 import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
@@ -16,6 +18,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class IdentityListener extends ProfileListenerPlugin {
+
+  private static final Log LOG = ExoLogger.getLogger(MatrixService.class);
 
   @Autowired
   private IdentityStorage identityStorage;
@@ -35,18 +39,22 @@ public class IdentityListener extends ProfileListenerPlugin {
   public void avatarUpdated(ProfileLifeCycleEvent event) {
     Profile profile = event.getProfile();
     String userMatrixID = (String) profile.getProperty(MatrixConstants.USER_MATRIX_ID);
-    if (StringUtils.isNotBlank(userMatrixID)) {
-      FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
-      String mimeType = "image/jpg";
-      if (avatarFileItem != null && avatarFileItem.getFileInfo() != null) {
-        if (!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
-          mimeType = avatarFileItem.getFileInfo().getMimetype();
-        }
-        String userAvatarUrl = matrixService.uploadFileOnMatrix("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte());
-        if (StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
-          matrixService.updateUserAvatar(userMatrixID, userAvatarUrl);
+    try {
+      if (StringUtils.isNotBlank(userMatrixID)) {
+        FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
+        String mimeType = "image/jpg";
+        if (avatarFileItem != null && avatarFileItem.getFileInfo() != null) {
+          if (!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
+            mimeType = avatarFileItem.getFileInfo().getMimetype();
+          }
+          String userAvatarUrl = matrixService.uploadFileOnMatrix("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte());
+          if (StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
+            matrixService.updateUserAvatar(userMatrixID, userAvatarUrl);
+          }
         }
       }
+    } catch (Exception e) {
+      LOG.error("Could not save the avatar of {} on Matrix", profile.getFullName(), e);
     }
   }
 }

--- a/services/src/main/java/io/meeds/chat/listeners/IdentityListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/IdentityListener.java
@@ -1,28 +1,25 @@
 package io.meeds.chat.listeners;
 
 import jakarta.annotation.PostConstruct;
-import org.apache.commons.lang3.StringUtils;
-import io.meeds.chat.service.utils.MatrixConstants;
-import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.service.MatrixService;
-import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.profile.ProfileListenerPlugin;
-import org.exoplatform.social.core.storage.api.IdentityStorage;
+import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
 
 @Component
 public class IdentityListener extends ProfileListenerPlugin {
 
   private static final Log LOG = ExoLogger.getLogger(MatrixService.class);
-
-  @Autowired
-  private IdentityStorage identityStorage;
 
   @Autowired
   private IdentityManager identityManager;
@@ -38,23 +35,11 @@ public class IdentityListener extends ProfileListenerPlugin {
   @Override
   public void avatarUpdated(ProfileLifeCycleEvent event) {
     Profile profile = event.getProfile();
-    String userMatrixID = (String) profile.getProperty(MatrixConstants.USER_MATRIX_ID);
+    String userMatrixId = (String) profile.getProperty(USER_MATRIX_ID);
     try {
-      if (StringUtils.isNotBlank(userMatrixID)) {
-        FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
-        String mimeType = "image/jpg";
-        if (avatarFileItem != null && avatarFileItem.getFileInfo() != null) {
-          if (!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
-            mimeType = avatarFileItem.getFileInfo().getMimetype();
-          }
-          String userAvatarUrl = matrixService.uploadFileOnMatrix("avatar-of-" + event.getUsername(), mimeType, avatarFileItem.getAsByte());
-          if (StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
-            matrixService.updateUserAvatar(userMatrixID, userAvatarUrl);
-          }
-        }
-      }
-    } catch (Exception e) {
-      LOG.error("Could not save the avatar of {} on Matrix", profile.getFullName(), e);
+      matrixService.updateUserAvatar(profile, userMatrixId);
+    } catch (JsonException | IOException | InterruptedException e) {
+      LOG.error("Could not update the avatar of the user {} on Matrix", profile.getFullName(), e);
     }
   }
 }

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
@@ -84,7 +84,11 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     String spaceDisplayName = space.getDisplayName();
     String roomId = matrixService.getRoomBySpace(space);
     if (StringUtils.isNotBlank(roomId)) {
-      matrixService.renameRoom(roomId, spaceDisplayName);
+      try {
+        matrixService.renameRoom(roomId, spaceDisplayName);
+      } catch (Exception e) {
+        LOG.error("Could not rename the room linked to the space {}", space.getDisplayName(), e);
+      }
     }
   }
 
@@ -106,7 +110,11 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     }
     String roomId = matrixService.getRoomBySpace(space);
     if (StringUtils.isNotBlank(roomId) && StringUtils.isNotBlank(matrixIdOfUser)) {
-      matrixService.joinUserToRoom(roomId, matrixIdOfUser);
+      try {
+        matrixService.joinUserToRoom(roomId, matrixIdOfUser);
+      } catch (Exception e) {
+        LOG.error("Could not join the user {} to the room of the space {} on Matrix", userId, space.getDisplayName(), e);
+      }
     }
   }
 
@@ -117,7 +125,11 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     String roomId = matrixService.getRoomBySpace(space);
     String matrixIdOfUser = matrixService.getMatrixIdForUser(userId);
     if (StringUtils.isNotBlank(roomId) && StringUtils.isNotBlank(matrixIdOfUser)) {
-      matrixService.kickUserFromRoom(roomId, matrixIdOfUser, MESSAGE_USER_KICKED_SPACE.formatted(space.getDisplayName()));
+      try {
+        matrixService.kickUserFromRoom(roomId, matrixIdOfUser, MESSAGE_USER_KICKED_SPACE.formatted(space.getDisplayName()));
+      } catch (Exception e) {
+        LOG.error("Could not kick the user {] from the room of the space {}", userId, space.getDisplayName(), e);
+      }
     }
   }
 
@@ -140,25 +152,29 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     roomId = matrixService.getRoomBySpace(space);
 
     if (StringUtils.isNotBlank(roomId)) {
-      // Disable inviting user but for Moderators
-      MatrixRoomPermissions matrixRoomPermissions = matrixService.getRoomSettings(roomId);
-      if (matrixRoomPermissions != null) {
-        if (SIMPLE_USER_ROLE.equals(userRole)) {
-          for (MatrixUserPermission userPermission : matrixRoomPermissions.getUsers()) {
-            String fullMatrixUserId = "@%s:%s".formatted(matrixIdOfUser, PropertyManager.getProperty(MATRIX_SERVER_NAME));
-            if (fullMatrixUserId.equals(userPermission.getUserName())) {
-              userPermission.setUserRole(userRole);
+      try {
+        // Disable inviting user but for Moderators
+        MatrixRoomPermissions matrixRoomPermissions = matrixService.getRoomSettings(roomId);
+        if (matrixRoomPermissions != null) {
+          if (SIMPLE_USER_ROLE.equals(userRole)) {
+            for (MatrixUserPermission userPermission : matrixRoomPermissions.getUsers()) {
+              String fullMatrixUserId = "@%s:%s".formatted(matrixIdOfUser, PropertyManager.getProperty(MATRIX_SERVER_NAME));
+              if (fullMatrixUserId.equals(userPermission.getUserName())) {
+                userPermission.setUserRole(userRole);
+              }
             }
+          } else {
+            MatrixUserPermission matrixUserPermission =
+                    new MatrixUserPermission("@%s:%s".formatted(matrixIdOfUser,
+                            PropertyManager.getProperty(MATRIX_SERVER_NAME)),
+                            userRole);
+            matrixRoomPermissions.getUsers().add(matrixUserPermission);
           }
-        } else {
-          MatrixUserPermission matrixUserPermission =
-                                                    new MatrixUserPermission("@%s:%s".formatted(matrixIdOfUser,
-                                                                                                PropertyManager.getProperty(MATRIX_SERVER_NAME)),
-                                                                             userRole);
-          matrixRoomPermissions.getUsers().add(matrixUserPermission);
         }
+        return matrixService.updateRoomSettings(roomId, matrixRoomPermissions);
+      } catch (Exception e) {
+        LOG.error("Could not update member roles in the space {}", space.getDisplayName(), e);
       }
-      return matrixService.updateRoomSettings(roomId, matrixRoomPermissions);
     }
     return false;
   }
@@ -168,14 +184,18 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     Space space = event.getSpace();
     String mimeType = "image/jpg";
     String roomId = matrixService.getRoomBySpace(space);
-    if (StringUtils.isNotBlank(roomId) && space.getAvatarAttachment() != null
-        && space.getAvatarAttachment().getImageBytes() != null) {
-      byte[] imageBytes = space.getAvatarAttachment().getImageBytes();
-      if (!"application/octet-stream".equals(space.getAvatarAttachment().getMimeType())) {
-        mimeType = space.getAvatarAttachment().getMimeType();
+    try {
+      if (StringUtils.isNotBlank(roomId) && space.getAvatarAttachment() != null
+              && space.getAvatarAttachment().getImageBytes() != null) {
+        byte[] imageBytes = space.getAvatarAttachment().getImageBytes();
+        if (!"application/octet-stream".equals(space.getAvatarAttachment().getMimeType())) {
+          mimeType = space.getAvatarAttachment().getMimeType();
+        }
+        String avatarURL = matrixService.uploadFileOnMatrix(space.getAvatarAttachment().getFileName(), mimeType, imageBytes);
+        matrixService.updateRoomAvatar(roomId, avatarURL);
       }
-      String avatarURL = matrixService.uploadFileOnMatrix(space.getAvatarAttachment().getFileName(), mimeType, imageBytes);
-      matrixService.updateRoomAvatar(roomId, avatarURL);
+    } catch (Exception e) {
+      LOG.error("Could not save the avatar of the space {}", space.getDisplayName(), e);
     }
   }
 
@@ -183,8 +203,12 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
   public void spaceDescriptionEdited(SpaceLifeCycleEvent event) {
     Space space = event.getSpace();
     String roomId = matrixService.getRoomBySpace(space);
-    if (StringUtils.isNotBlank(roomId)) {
-      matrixService.updateRoomDescription(roomId, space.getDescription());
+    try {
+      if (StringUtils.isNotBlank(roomId)) {
+        matrixService.updateRoomDescription(roomId, space.getDescription());
+      }
+    } catch (Exception e) {
+      LOG.error("Could not save the description of space {} ", space.getDisplayName(), e);
     }
   }
 
@@ -193,7 +217,11 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     Space space = event.getSpace();
     String roomId = matrixService.getRoomBySpace(space);
     if (StringUtils.isNotBlank(roomId)) {
-      matrixService.deleteRoom(roomId);
+      try {
+        matrixService.deleteRoom(roomId);
+      } catch (Exception e) {
+        LOG.error("Could not delete the room {} linked to the space {}", roomId, space.getDisplayName());
+      }
     }
   }
 }

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -52,17 +52,18 @@ public class MatrixService {
   private String              matrixAccessToken;
 
   @PostConstruct
-  public void init() {
+  public void init() throws JsonException, IOException, InterruptedException {
     this.getMatrixAccessToken();
   }
 
-  private String getMatrixAccessToken() {
+  private String getMatrixAccessToken() throws JsonException, IOException, InterruptedException {
     if (StringUtils.isBlank(this.matrixAccessToken)) {
       try {
         String jwtAccessToken = this.getJWTSessionToken(PropertyManager.getProperty(MATRIX_ADMIN_USERNAME));
         this.matrixAccessToken = MatrixHttpClient.getAdminAccessToken(jwtAccessToken);
       } catch (JsonException | IOException | InterruptedException e) {
         LOG.error("Could not get Matrix Access token for the administrator account !");
+        throw e;
       }
     }
     return this.matrixAccessToken;
@@ -151,7 +152,7 @@ public class MatrixService {
    * @param isNew boolean if the user is new, then true
    * @return String the matrix user ID
    */
-  public String saveUserAccount(User user, boolean isNew, boolean isEnableUserOperation) {
+  public String saveUserAccount(User user, boolean isNew, boolean isEnableUserOperation) throws JsonException, IOException, InterruptedException {
     String matrixId = MatrixHttpClient.saveUserAccount(user,
                                                        user.getUserName(),
                                                        isNew,
@@ -167,47 +168,47 @@ public class MatrixService {
     return matrixId;
   }
 
-  public String uploadFileOnMatrix(String fileName, String mimeType, byte[] fileBytes) {
+  public String uploadFileOnMatrix(String fileName, String mimeType, byte[] fileBytes) throws JsonException, IOException, InterruptedException {
     return MatrixHttpClient.uploadFile(fileName, mimeType, fileBytes, this.getMatrixAccessToken());
   }
 
-  public void updateUserAvatar(String userMatrixID, String userAvatarUrl) {
+  public void updateUserAvatar(String userMatrixID, String userAvatarUrl) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl, this.getMatrixAccessToken());
   }
 
-  public void disableAccount(String matrixUsername) {
+  public void disableAccount(String matrixUsername) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.disableAccount(matrixUsername, false, this.getMatrixAccessToken());
   }
 
-  public boolean updateRoomDescription(String roomId, String description) {
+  public boolean updateRoomDescription(String roomId, String description) throws JsonException, IOException, InterruptedException {
     return MatrixHttpClient.updateRoomDescription(roomId, description, this.getMatrixAccessToken());
   }
 
-  public void updateRoomAvatar(String roomId, String avatarURL) {
+  public void updateRoomAvatar(String roomId, String avatarURL) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.updateRoomAvatar(roomId, avatarURL, this.getMatrixAccessToken());
   }
 
-  public MatrixRoomPermissions getRoomSettings(String roomId) {
+  public MatrixRoomPermissions getRoomSettings(String roomId) throws JsonException, IOException, InterruptedException {
     return MatrixHttpClient.getRoomSettings(roomId, this.getMatrixAccessToken());
   }
 
-  public boolean updateRoomSettings(String roomId, MatrixRoomPermissions matrixRoomPermissions) {
+  public boolean updateRoomSettings(String roomId, MatrixRoomPermissions matrixRoomPermissions) throws JsonException, IOException, InterruptedException {
     return MatrixHttpClient.updateRoomSettings(roomId, matrixRoomPermissions, this.getMatrixAccessToken()) != null;
   }
 
-  public void kickUserFromRoom(String roomId, String matrixIdOfUser, String message) {
+  public void kickUserFromRoom(String roomId, String matrixIdOfUser, String message) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.kickUserFromRoom(roomId, matrixIdOfUser, message, this.getMatrixAccessToken());
   }
 
-  public void joinUserToRoom(String roomId, String matrixIdOfUser) {
+  public void joinUserToRoom(String roomId, String matrixIdOfUser) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.joinUserToRoom(roomId, matrixIdOfUser, this.getMatrixAccessToken());
   }
 
-  public void renameRoom(String roomId, String spaceDisplayName) {
+  public void renameRoom(String roomId, String spaceDisplayName) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.renameRoom(roomId, spaceDisplayName, this.getMatrixAccessToken());
   }
 
-  public void makeUserAdminInRoom(String matrixRoomId, String matrixIdOfUser) {
+  public void makeUserAdminInRoom(String matrixRoomId, String matrixIdOfUser) throws JsonException, IOException, InterruptedException {
     MatrixHttpClient.makeUserAdminInRoom(matrixRoomId, matrixIdOfUser, this.getMatrixAccessToken());
   }
 
@@ -228,7 +229,7 @@ public class MatrixService {
    *
    * @param roomId the room identifier
    */
-  public void deleteRoom(String roomId) {
+  public void deleteRoom(String roomId) throws JsonException, IOException, InterruptedException {
     boolean success =  MatrixHttpClient.deleteRoom(roomId, getMatrixAccessToken());
     if(success) {
       matrixRoomStorage.removeMatrixRoom(roomId);

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -10,6 +10,7 @@ import io.meeds.chat.storage.MatrixRoomStorage;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
+import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.PropertyManager;
 
@@ -22,6 +23,7 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -45,6 +47,9 @@ public class MatrixService {
 
   @Autowired
   private IdentityManager     identityManager;
+
+  @Autowired
+  private IdentityStorage     identityStorage;
 
   @Autowired
   private OrganizationService organizationService;
@@ -172,8 +177,24 @@ public class MatrixService {
     return MatrixHttpClient.uploadFile(fileName, mimeType, fileBytes, this.getMatrixAccessToken());
   }
 
-  public void updateUserAvatar(String userMatrixID, String userAvatarUrl) throws JsonException, IOException, InterruptedException {
-    MatrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl, this.getMatrixAccessToken());
+  public void updateUserAvatar(Profile profile, String userMatrixID) throws JsonException, IOException, InterruptedException {
+    try {
+      if (StringUtils.isNotBlank(userMatrixID)) {
+        FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
+        String mimeType = "image/jpg";
+        if (avatarFileItem != null && avatarFileItem.getFileInfo() != null && !"DEFAULT_AVATAR".equals(avatarFileItem.getFileInfo().getName())) {
+          if (!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
+            mimeType = avatarFileItem.getFileInfo().getMimetype();
+          }
+          String userAvatarUrl = this.uploadFileOnMatrix("avatar-of-" + profile.getIdentity().getRemoteId() + ".jpg", mimeType, avatarFileItem.getAsByte());
+          if (StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
+            MatrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl, this.getMatrixAccessToken());
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Could not save the avatar of {} on Matrix", profile.getFullName(), e);
+    }
   }
 
   public void disableAccount(String matrixUsername) throws JsonException, IOException, InterruptedException {

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -74,7 +74,7 @@ public class MatrixHttpClient {
           LOG.error("Error Authenticating admin account with JWT, Matrix server returned HTTP {} error {}",
                     String.valueOf(response.statusCode()),
                     response.body());
-          return null;
+          throw new IllegalStateException("Could not authenticate Admin account on Matrix");
         }
       }
     } catch (Exception e) {
@@ -377,14 +377,10 @@ public class MatrixHttpClient {
         }
         return fullMatrixID.substring(1, fullMatrixID.indexOf(":"));
       } else {
-        LOG.error("Error creating a user account, Matrix server returned HTTP {} error {}",
-                  String.valueOf(response.statusCode()),
-                  response.body());
-        return null;
+        throw new RuntimeException("Error creating a user account, Matrix server returned HTTP {} error {}");
       }
     } catch (Exception e) {
-      LOG.error("Could not create a user account on Matrix", e);
-      return null;
+      throw new RuntimeException("Could not create a user account on Matrix", e);
     }
   }
 

--- a/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
@@ -1,7 +1,6 @@
 package io.meeds.chat.upgrade;
 
 import io.meeds.chat.service.MatrixService;
-import io.meeds.chat.service.utils.MatrixConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -165,6 +164,9 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
                 matrixService.joinUserToRoom(spaceRoomId, userMatrixId);
               }
             }
+          }
+          if(StringUtils.isNotBlank(userMatrixId)) {
+            matrixService.updateUserAvatar(userProfile, userMatrixId);
           }
         }
         checkedUsers += usersArray.length;

--- a/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
@@ -163,7 +163,7 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
         LOG.info("Created a Matrix account for {} of {} users", checkedUsers, usersCount);
       }
     } catch (Exception e) {
-      LOG.error("Error while loading user identities", e);
+      throw new RuntimeException("Error while creating accounts for users on Matrix", e);
     } finally {
       RequestLifeCycle.end();
     }

--- a/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
@@ -36,7 +36,7 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
 
   private int              SPACES_THRESHOLD   = 20;
 
-  private int              LOADED_USERS_COUNT = 10;
+  private int              LOADED_USERS_COUNT = 50;
 
   public MatrixRoomAndAccountsUpgradePlugin(InitParams initParams,
                                             SpaceService spaceService,
@@ -156,11 +156,19 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
           Profile userProfile = userIdentity.getProfile();
           String userMatrixId = (String) userProfile.getProperty(USER_MATRIX_ID);
           if (StringUtils.isBlank(userMatrixId)) {
-            matrixService.saveUserAccount(user, true, false);
+            userMatrixId = matrixService.saveUserAccount(user, true, false);
+            ListAccess<Space> userSpaces = spaceService.getMemberSpaces(user.getUserName());
+            Space[] spaceArray = userSpaces.load(0, userSpaces.getSize());
+            for(Space space : spaceArray) {
+              String spaceRoomId = matrixService.getRoomBySpace(space);
+              if(StringUtils.isNotBlank(spaceRoomId)) {
+                matrixService.joinUserToRoom(spaceRoomId, userMatrixId);
+              }
+            }
           }
         }
         checkedUsers += usersArray.length;
-        LOG.info("Created a Matrix account for {} of {} users", checkedUsers, usersCount);
+        LOG.info("Checked Matrix account for {} of {} users", checkedUsers, usersCount);
       }
     } catch (Exception e) {
       throw new RuntimeException("Error while creating accounts for users on Matrix", e);

--- a/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -139,7 +139,7 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
-      <name>MatrixRoomAndAccountsUpgradePlugin</name>
+      <name>MatrixRoomAndAccountsDataInitialization</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.chat.upgrade.MatrixRoomAndAccountsUpgradePlugin</type>
       <description>Create Matrix rooms for existing spaces</description>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -48,6 +48,8 @@
               if(resp.user_id) {
                 localStorage.setItem("matrix_user_id", resp.user_id);
                 localStorage.setItem("matrix_access_token", resp.access_token);
+                this.loadRooms();
+                this.$matrixService.saveFilter().then(filterResponse => this.$matrixService.longPollingSync(filterResponse.filter_id));
               } else {
                 this.$root.$emit('alert-message', `${this.$t('exo.matrix.login.failed')}`, 'error');
                 this.$root.$emit('matrix-login-failed');
@@ -61,10 +63,7 @@
       this.$root.$on('chat-event-total-unread-updated',e => {
         this.totalUnreadMessages = e;
       });
-      this.loadRooms();
-      this.$matrixService.saveFilter().then(filterResponse => this.$matrixService.longPollingSync(filterResponse.filter_id));
       document.addEventListener('matrix-message-received', event => this.messageReceived(event));
-
     },
     beforeDestroy() {
       this.$root.$off('chat-event-total-unread-updated',e => this.totalUnreadMessages = e);

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -59,6 +59,9 @@
             this.$root.$emit('alert-message', `${this.$t('exo.matrix.jwt.disabled')}`, 'error');
           }
         });
+      } else {
+        this.loadRooms();
+        this.$matrixService.saveFilter().then(filterResponse => this.$matrixService.longPollingSync(filterResponse.filter_id));
       }
       this.$root.$on('chat-event-total-unread-updated',e => {
         this.totalUnreadMessages = e;

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -252,6 +252,9 @@ export function toRoomObject(rooms, currentMemberId) {
     if(!roomItem.avatarUrl) {
       roomItem.avatarUrl = DEFAULT_ROOM_AVATAR;
     }
+    if(!roomItem.updated) {
+      roomItem.updated = 0;
+    }
     myRooms.totalUnreadMessages += roomItem.unreadMessages;
     myRooms.rooms.push(roomItem);
   }


### PR DESCRIPTION
The fix interrupts the upgrade if  at least one user isn't created on Matrix, besides, it adds some other enhancements : 
 - Update user avatars while upgrading
 - Check if there are already synchronized rooms and add the synchronized users to them
 - Load rooms and save the sync filter only after a successful  authentication