### PR TITLE
feat: update the display name of the Matrix admin during startup - EXO-75511

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -36,7 +36,7 @@
   </build>
 
   <properties>
-    <exo.test.coverage.ratio>0.05</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.24</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
@@ -4,9 +4,7 @@ import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import io.meeds.chat.model.MatrixUserPermission;
-import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.service.MatrixService;
-import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -16,7 +14,6 @@ import org.exoplatform.social.core.space.SpaceListenerPlugin;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixUserLoginListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixUserLoginListener.java
@@ -2,7 +2,6 @@ package io.meeds.chat.listeners;
 
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
-import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.service.MatrixService;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
@@ -18,13 +17,11 @@ import org.exoplatform.services.organization.User;
 import org.exoplatform.services.security.ConversationRegistry;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
-import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_RESTRICTED_USERS_GROUP;
-import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
 
 @Component
 public class MatrixUserLoginListener extends Listener<ConversationRegistry, ConversationState> {

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -9,6 +9,7 @@ import io.meeds.chat.model.SpaceRoom;
 import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.storage.MatrixRoomStorage;
 import jakarta.annotation.PostConstruct;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.file.model.FileItem;
@@ -56,24 +57,57 @@ public class MatrixService {
   @Autowired
   private OrganizationService organizationService;
 
+  @Autowired
+  private MatrixHttpClient    matrixHttpClient;
+
   private String              matrixAccessToken;
+
+  public MatrixService(MatrixRoomStorage matrixRoomStorage,
+                       IdentityManager identityManager,
+                       IdentityStorage identityStorage,
+                       OrganizationService organizationService,
+                       MatrixHttpClient matrixHttpClient) {
+    this.matrixRoomStorage = matrixRoomStorage;
+    this.identityManager = identityManager;
+    this.identityStorage = identityStorage;
+    this.organizationService = organizationService;
+    this.matrixHttpClient = matrixHttpClient;
+  }
 
   @PostConstruct
   public void init() throws JsonException, IOException, InterruptedException {
     this.getMatrixAccessToken();
+
+    String userFullMatrixID = "@" + PropertyManager.getProperty(MATRIX_ADMIN_USERNAME) + ":"
+        + PropertyManager.getProperty(MATRIX_SERVER_NAME);
+    String displayName = System.getProperty(MATRIX_ADMIN_DISPLAY_NAME, "Chat Bot");
+    if (StringUtils.isNotBlank(displayName)) {
+      this.updateUserDisplayName(userFullMatrixID, displayName);
+    }
   }
 
   private String getMatrixAccessToken() throws JsonException, IOException, InterruptedException {
     if (StringUtils.isBlank(this.matrixAccessToken)) {
       try {
         String jwtAccessToken = this.getJWTSessionToken(PropertyManager.getProperty(MATRIX_ADMIN_USERNAME));
-        this.matrixAccessToken = MatrixHttpClient.getAdminAccessToken(jwtAccessToken);
+        this.matrixAccessToken = matrixHttpClient.getAdminAccessToken(jwtAccessToken);
       } catch (JsonException | IOException | InterruptedException e) {
         LOG.error("Could not get Matrix Access token for the administrator account !");
         throw e;
       }
     }
     return this.matrixAccessToken;
+  }
+
+  public void updateUserDisplayName(String matrixFullID, String newDisplayName) {
+    try {
+      String currentUserDisplayName = matrixHttpClient.getUserDisplayName(matrixFullID, getMatrixAccessToken());
+      if (StringUtils.isNotBlank(currentUserDisplayName) && !currentUserDisplayName.equals(newDisplayName)) {
+        matrixHttpClient.updateUserDisplayName(matrixFullID, newDisplayName, getMatrixAccessToken());
+      }
+    } catch (Exception e) {
+      LOG.error("Couldn't update the display name of the user {}", matrixFullID, e);
+    }
   }
 
   /**
@@ -133,7 +167,7 @@ public class MatrixService {
   public String createRoomForSpaceOnMatrix(Space space) throws Exception {
     String teamDisplayName = space.getDisplayName();
     String description = space.getDescription() != null ? space.getDescription() : "";
-    return MatrixHttpClient.createRoom(teamDisplayName, description, getMatrixAccessToken());
+    return matrixHttpClient.createRoom(teamDisplayName, description, getMatrixAccessToken());
   }
 
   /**
@@ -173,8 +207,10 @@ public class MatrixService {
    * @param isNew boolean if the user is new, then true
    * @return String the matrix user ID
    */
-  public String saveUserAccount(User user, boolean isNew, boolean isEnableUserOperation) throws JsonException, IOException, InterruptedException {
-    String matrixId = MatrixHttpClient.saveUserAccount(user,
+  public String saveUserAccount(User user, boolean isNew, boolean isEnableUserOperation) throws JsonException,
+                                                                                         IOException,
+                                                                                         InterruptedException {
+    String matrixId = matrixHttpClient.saveUserAccount(user,
                                                        user.getUserName(),
                                                        isNew,
                                                        this.getMatrixAccessToken(),
@@ -189,8 +225,10 @@ public class MatrixService {
     return matrixId;
   }
 
-  public String uploadFileOnMatrix(String fileName, String mimeType, byte[] fileBytes) throws JsonException, IOException, InterruptedException {
-    return MatrixHttpClient.uploadFile(fileName, mimeType, fileBytes, this.getMatrixAccessToken());
+  public String uploadFileOnMatrix(String fileName, String mimeType, byte[] fileBytes) throws JsonException,
+                                                                                       IOException,
+                                                                                       InterruptedException {
+    return matrixHttpClient.uploadFile(fileName, mimeType, fileBytes, this.getMatrixAccessToken());
   }
 
   public void updateUserAvatar(Profile profile, String userMatrixID) throws JsonException, IOException, InterruptedException {
@@ -198,13 +236,16 @@ public class MatrixService {
       if (StringUtils.isNotBlank(userMatrixID)) {
         FileItem avatarFileItem = identityStorage.getAvatarFile(profile.getIdentity());
         String mimeType = "image/jpg";
-        if (avatarFileItem != null && avatarFileItem.getFileInfo() != null && !"DEFAULT_AVATAR".equals(avatarFileItem.getFileInfo().getName())) {
+        if (avatarFileItem != null && avatarFileItem.getFileInfo() != null
+            && !"DEFAULT_AVATAR".equals(avatarFileItem.getFileInfo().getName())) {
           if (!"application/octet-stream".equals(avatarFileItem.getFileInfo().getMimetype())) {
             mimeType = avatarFileItem.getFileInfo().getMimetype();
           }
-          String userAvatarUrl = this.uploadFileOnMatrix("avatar-of-" + profile.getIdentity().getRemoteId() + ".jpg", mimeType, avatarFileItem.getAsByte());
+          String userAvatarUrl = this.uploadFileOnMatrix("avatar-of-" + profile.getIdentity().getRemoteId() + ".jpg",
+                                                         mimeType,
+                                                         avatarFileItem.getAsByte());
           if (StringUtils.isNotBlank(userMatrixID) && StringUtils.isNotBlank(userAvatarUrl)) {
-            MatrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl, this.getMatrixAccessToken());
+            matrixHttpClient.updateUserAvatar(userMatrixID, userAvatarUrl, this.getMatrixAccessToken());
           }
         }
       }
@@ -214,14 +255,15 @@ public class MatrixService {
   }
 
   public void disableAccount(String matrixUsername) throws JsonException, IOException, InterruptedException {
-    MatrixHttpClient.disableAccount(matrixUsername, false, this.getMatrixAccessToken());
+    matrixHttpClient.disableAccount(matrixUsername, false, this.getMatrixAccessToken());
   }
 
-  public boolean updateRoomDescription(String roomId, String description) throws JsonException, IOException, InterruptedException {
-    return MatrixHttpClient.updateRoomDescription(roomId, description, this.getMatrixAccessToken());
+  public boolean updateRoomDescription(String roomId,
+                                       String description) throws JsonException, IOException, InterruptedException {
+    return matrixHttpClient.updateRoomDescription(roomId, description, this.getMatrixAccessToken());
   }
 
-  public void updateRoomAvatar(Space space,String roomId) throws Exception {
+  public void updateRoomAvatar(Space space, String roomId) throws Exception {
     String mimeType = "";
     String avatarURL;
     String fileExtension = "";
@@ -230,17 +272,18 @@ public class MatrixService {
       Identity identity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
       FileItem spaceAvatarFileItem = identityManager.getAvatarFile(identity);
       byte[] imageBytes = new byte[0];
-      if(space.getAvatarAttachment() != null
-              && space.getAvatarAttachment().getImageBytes() != null) {
+      if (space.getAvatarAttachment() != null && space.getAvatarAttachment().getImageBytes() != null) {
         imageBytes = space.getAvatarAttachment().getImageBytes();
         mimeType = space.getAvatarAttachment().getMimeType();
         fileName = space.getAvatarAttachment().getFileName();
-        fileExtension = StringUtils.isNotBlank(fileName) && fileName.contains(".") ? fileName.substring(fileName.lastIndexOf(".")) : ".jpg";
+        fileExtension = StringUtils.isNotBlank(fileName) && fileName.contains(".") ? fileName.substring(fileName.lastIndexOf("."))
+                                                                                   : ".jpg";
       } else if ((spaceAvatarFileItem != null && spaceAvatarFileItem.getAsByte() != null)) {
         imageBytes = spaceAvatarFileItem.getAsByte();
         mimeType = spaceAvatarFileItem.getFileInfo().getMimetype();
         fileName = spaceAvatarFileItem.getFileInfo().getName();
-        fileExtension = StringUtils.isNotBlank(fileName) && fileName.contains(".") ? fileName.substring(fileName.lastIndexOf(".")) : ".jpg";
+        fileExtension = StringUtils.isNotBlank(fileName) && fileName.contains(".") ? fileName.substring(fileName.lastIndexOf("."))
+                                                                                   : ".jpg";
       }
       if ("application/octet-stream".equals(mimeType)) {
         mimeType = "image/jpg";
@@ -248,7 +291,7 @@ public class MatrixService {
       fileName = "avatar-space-%s%s".formatted(space.getPrettyName(), fileExtension);
       if (StringUtils.isNotBlank(roomId) && imageBytes != null) {
         avatarURL = this.uploadFileOnMatrix(fileName, mimeType, imageBytes);
-        MatrixHttpClient.updateRoomAvatar(roomId, avatarURL, this.getMatrixAccessToken());
+        matrixHttpClient.updateRoomAvatar(roomId, avatarURL, this.getMatrixAccessToken());
       }
     } catch (Exception e) {
       throw new Exception("Could not save the avatar of the space %s".formatted(space.getDisplayName()), e);
@@ -256,27 +299,32 @@ public class MatrixService {
   }
 
   public MatrixRoomPermissions getRoomSettings(String roomId) throws JsonException, IOException, InterruptedException {
-    return MatrixHttpClient.getRoomSettings(roomId, this.getMatrixAccessToken());
+    return matrixHttpClient.getRoomSettings(roomId, this.getMatrixAccessToken());
   }
 
-  public boolean updateRoomSettings(String roomId, MatrixRoomPermissions matrixRoomPermissions) throws JsonException, IOException, InterruptedException {
-    return MatrixHttpClient.updateRoomSettings(roomId, matrixRoomPermissions, this.getMatrixAccessToken()) != null;
+  public boolean updateRoomSettings(String roomId, MatrixRoomPermissions matrixRoomPermissions) throws JsonException,
+                                                                                                IOException,
+                                                                                                InterruptedException {
+    return matrixHttpClient.updateRoomSettings(roomId, matrixRoomPermissions, this.getMatrixAccessToken()) != null;
   }
 
-  public void kickUserFromRoom(String roomId, String matrixIdOfUser, String message) throws JsonException, IOException, InterruptedException {
-    MatrixHttpClient.kickUserFromRoom(roomId, matrixIdOfUser, message, this.getMatrixAccessToken());
+  public void kickUserFromRoom(String roomId, String matrixIdOfUser, String message) throws JsonException,
+                                                                                     IOException,
+                                                                                     InterruptedException {
+    matrixHttpClient.kickUserFromRoom(roomId, matrixIdOfUser, message, this.getMatrixAccessToken());
   }
 
   public void joinUserToRoom(String roomId, String matrixIdOfUser) throws JsonException, IOException, InterruptedException {
-    MatrixHttpClient.joinUserToRoom(roomId, matrixIdOfUser, this.getMatrixAccessToken());
+    matrixHttpClient.joinUserToRoom(roomId, matrixIdOfUser, this.getMatrixAccessToken());
   }
 
   public void renameRoom(String roomId, String spaceDisplayName) throws JsonException, IOException, InterruptedException {
-    MatrixHttpClient.renameRoom(roomId, spaceDisplayName, this.getMatrixAccessToken());
+    matrixHttpClient.renameRoom(roomId, spaceDisplayName, this.getMatrixAccessToken());
   }
 
-  public void makeUserAdminInRoom(String matrixRoomId, String matrixIdOfUser) throws JsonException, IOException, InterruptedException {
-    MatrixHttpClient.makeUserAdminInRoom(matrixRoomId, matrixIdOfUser, this.getMatrixAccessToken());
+  public void makeUserAdminInRoom(String matrixRoomId,
+                                  String matrixIdOfUser) throws JsonException, IOException, InterruptedException {
+    matrixHttpClient.makeUserAdminInRoom(matrixRoomId, matrixIdOfUser, this.getMatrixAccessToken());
   }
 
   /**
@@ -291,7 +339,7 @@ public class MatrixService {
   public String createRoom(Space space) throws Exception {
     String teamDisplayName = space.getDisplayName();
     String description = space.getDescription() != null ? space.getDescription() : "";
-    String matrixRoomId = MatrixHttpClient.createRoom(teamDisplayName, description, this.getMatrixAccessToken());
+    String matrixRoomId = matrixHttpClient.createRoom(teamDisplayName, description, this.getMatrixAccessToken());
     if(StringUtils.isNotBlank(matrixRoomId)) {
       //link the room on Meeds server
       this.linkSpaceToMatrixRoom(space, matrixRoomId);
@@ -317,8 +365,8 @@ public class MatrixService {
    * @param roomId the room identifier
    */
   public void deleteRoom(String roomId) throws JsonException, IOException, InterruptedException {
-    boolean success =  MatrixHttpClient.deleteRoom(roomId, getMatrixAccessToken());
-    if(success) {
+    boolean success = matrixHttpClient.deleteRoom(roomId, getMatrixAccessToken());
+    if (success) {
       matrixRoomStorage.removeMatrixRoom(roomId);
     }
   }

--- a/services/src/main/java/io/meeds/chat/service/utils/HTTPHelper.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/HTTPHelper.java
@@ -1,0 +1,78 @@
+package io.meeds.chat.service.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+
+import static io.meeds.chat.service.utils.MatrixConstants.*;
+
+public class HTTPHelper {
+  protected static HttpResponse<String> sendHttpGetRequest(String url, String token) throws IOException, InterruptedException {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).header(AUTHORIZATION, BEARER + token).GET().build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected static HttpResponse<String> sendHttpPostRequest(String url, String token, String contentAsJson) throws IOException,
+                                                                                                            InterruptedException {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request;
+    if (StringUtils.isNotBlank(token)) {
+      request = HttpRequest.newBuilder()
+                           .uri(URI.create(url))
+                           .header(AUTHORIZATION, BEARER + token)
+                           .POST(HttpRequest.BodyPublishers.ofString(contentAsJson))
+                           .build();
+    } else {
+      request = HttpRequest.newBuilder().uri(URI.create(url)).POST(HttpRequest.BodyPublishers.ofString(contentAsJson)).build();
+    }
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected static HttpResponse<String> sendHttpPostRequest(String url,
+                                                            String token,
+                                                            String mimeType,
+                                                            byte[] fileContent) throws IOException, InterruptedException {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request;
+    request = HttpRequest.newBuilder()
+                         .uri(URI.create(url))
+                         .header(AUTHORIZATION, BEARER + token)
+                         .header(CONTENT_TYPE, mimeType)
+                         .POST(HttpRequest.BodyPublishers.ofByteArray(fileContent))
+                         .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected static HttpResponse<String> sendHttpPutRequest(String url, String token, String contentAsJson) throws IOException,
+                                                                                                           InterruptedException {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request = HttpRequest.newBuilder()
+                                     .uri(URI.create(url))
+                                     .header(AUTHORIZATION, BEARER + token)
+                                     .PUT(HttpRequest.BodyPublishers.ofString(contentAsJson))
+                                     .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected static HttpResponse<String> sendHttpDeleteRequest(String url,
+                                                              String token,
+                                                              String contentAsJson) throws IOException, InterruptedException {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request = HttpRequest.newBuilder()
+                                     .uri(URI.create(url))
+                                     .header(AUTHORIZATION, BEARER + token)
+                                     .method("DELETE", HttpRequest.BodyPublishers.ofString(contentAsJson))
+                                     .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  public static void sendInvitationToMembers(ArrayList<String> strings, String matrixRoomId) {
+
+  }
+}

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixConstants.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixConstants.java
@@ -14,6 +14,8 @@ public class MatrixConstants {
 
   public static final String                   MATRIX_ADMIN_USERNAME                          = "meeds.matrix.user.name";
 
+  public static final String                   MATRIX_ADMIN_DISPLAY_NAME                      = "meeds.matrix.user.display.name";
+
   public static final String                   MATRIX_SERVER_NAME                             = "meeds.matrix.server.name";
 
   public static final String                   MATRIX_RESTRICTED_USERS_GROUP                  =

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -2,7 +2,6 @@ package io.meeds.chat.service.utils;
 
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
-import org.apache.commons.codec.language.MatchRatingApproachEncoder;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import org.exoplatform.commons.utils.PropertyManager;
@@ -13,25 +12,21 @@ import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.exoplatform.ws.frameworks.json.impl.JsonGeneratorImpl;
 import org.exoplatform.ws.frameworks.json.value.JsonValue;
 import org.jsoup.Jsoup;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URLEncoder;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
-import java.util.ArrayList;
 
+import static io.meeds.chat.service.utils.HTTPHelper.*;
 import static io.meeds.chat.service.utils.MatrixConstants.*;
 import static java.lang.Character.toLowerCase;
 
+@Component
 public class MatrixHttpClient {
   private static final Log LOG = ExoLogger.getLogger(MatrixHttpClient.class.toString());
-
-  private MatrixHttpClient() {
-  }
 
   /**
    * Get an authenticated access token for the administrative tasks
@@ -42,7 +37,7 @@ public class MatrixHttpClient {
    * @throws IOException
    * @throws InterruptedException
    */
-  public static String getAdminAccessToken(String userJWTToken) throws JsonException, IOException, InterruptedException {
+  public String getAdminAccessToken(String userJWTToken) throws JsonException, IOException, InterruptedException {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -91,8 +86,7 @@ public class MatrixHttpClient {
    * @param password the user password
    * @return String : access token for the authenticated user
    */
-  public static String authenticateUser(String userName,
-                                        String password) throws JsonException, IOException, InterruptedException {
+  public String authenticateUser(String userName, String password) throws JsonException, IOException, InterruptedException {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -109,7 +103,7 @@ public class MatrixHttpClient {
 
         """.formatted(userName, password);
     try {
-      HttpResponse<String> response = sendHttpPostRequest(url, null, payload);
+      HttpResponse<String> response = sendHttpPostRequest(url, "", payload);
       if (response.statusCode() >= 200 && response.statusCode() < 300) {
         JsonGeneratorImpl jsonGenerator = new JsonGeneratorImpl();
         return jsonGenerator.createJsonObjectFromString(response.body()).getElement("access_token").getStringValue();
@@ -136,7 +130,7 @@ public class MatrixHttpClient {
 
   }
 
-  public static String createRoom(String name, String description, String token) throws Exception {
+  public String createRoom(String name, String description, String token) throws Exception {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -189,7 +183,7 @@ public class MatrixHttpClient {
     }
   }
 
-  private static String cleanDescription(String description) {
+  private String cleanDescription(String description) {
     String plainTextDescription = Jsoup.parse(description).text();
     if (StringUtils.isNotBlank(plainTextDescription)) {
       return plainTextDescription.replace("\"", "\\\"");
@@ -197,71 +191,7 @@ public class MatrixHttpClient {
     return "";
   }
 
-  protected static HttpResponse<String> sendHttpGetRequest(String url, String token) throws IOException, InterruptedException {
-    HttpClient client = HttpClient.newHttpClient();
-    HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).header(AUTHORIZATION, BEARER + token).GET().build();
-    return client.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  protected static HttpResponse<String> sendHttpPostRequest(String url, String token, String contentAsJson) throws IOException,
-                                                                                                            InterruptedException {
-    HttpClient client = HttpClient.newHttpClient();
-    HttpRequest request;
-    if (StringUtils.isNotBlank(token)) {
-      request = HttpRequest.newBuilder()
-                           .uri(URI.create(url))
-                           .header(AUTHORIZATION, BEARER + token)
-                           .POST(HttpRequest.BodyPublishers.ofString(contentAsJson))
-                           .build();
-    } else {
-      request = HttpRequest.newBuilder().uri(URI.create(url)).POST(HttpRequest.BodyPublishers.ofString(contentAsJson)).build();
-    }
-    return client.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  protected static HttpResponse<String> sendHttpPostRequest(String url,
-                                                            String token,
-                                                            String mimeType,
-                                                            byte[] fileContent) throws IOException, InterruptedException {
-    HttpClient client = HttpClient.newHttpClient();
-    HttpRequest request;
-    request = HttpRequest.newBuilder()
-                         .uri(URI.create(url))
-                         .header(AUTHORIZATION, BEARER + token)
-                         .header(CONTENT_TYPE, mimeType)
-                         .POST(HttpRequest.BodyPublishers.ofByteArray(fileContent))
-                         .build();
-    return client.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  protected static HttpResponse<String> sendHttpPutRequest(String url, String token, String contentAsJson) throws IOException,
-                                                                                                           InterruptedException {
-    HttpClient client = HttpClient.newHttpClient();
-    HttpRequest request = HttpRequest.newBuilder()
-                                     .uri(URI.create(url))
-                                     .header(AUTHORIZATION, BEARER + token)
-                                     .PUT(HttpRequest.BodyPublishers.ofString(contentAsJson))
-                                     .build();
-    return client.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  protected static HttpResponse<String> sendHttpDeleteRequest(String url,
-                                                              String token,
-                                                              String contentAsJson) throws IOException, InterruptedException {
-    HttpClient client = HttpClient.newHttpClient();
-    HttpRequest request = HttpRequest.newBuilder()
-                                     .uri(URI.create(url))
-                                     .header(AUTHORIZATION, BEARER + token)
-                                     .method("DELETE", HttpRequest.BodyPublishers.ofString(contentAsJson))
-                                     .build();
-    return client.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  public static void sendInvitationToMembers(ArrayList<String> strings, String matrixRoomId) {
-
-  }
-
-  public static String createUserAccount(User user, String token) {
+  public String createUserAccount(User user, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -299,11 +229,67 @@ public class MatrixHttpClient {
     }
   }
 
-  public static String saveUserAccount(User user,
-                                       String matrixUserId,
-                                       boolean isNew,
-                                       String token,
-                                       boolean isEnableUserOperation) {
+  /**
+   * Sets a new display name for the user
+   * 
+   * @param userMatrixId the ID of the user on Matrix
+   * @param displayName the new display name
+   * @param token the access token
+   * @throws IOException
+   * @throws InterruptedException
+   * @throws JsonException
+   */
+  public void updateUserDisplayName(String userMatrixId, String displayName, String token) throws IOException,
+                                                                                           InterruptedException,
+                                                                                           JsonException {
+    if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
+      throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
+    }
+    String encodedUserMatrixId = URLEncoder.encode(userMatrixId, StandardCharsets.UTF_8);
+
+    String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_matrix/client/v3/profile/" + encodedUserMatrixId
+        + "/displayname";
+
+    String payload = """
+        {
+          "displayname": "%s"
+        }
+        """.formatted(displayName);
+    HttpResponse<String> response = sendHttpPutRequest(url, token, payload);
+    if (response.statusCode() >= 200 && response.statusCode() < 300) {
+      LOG.info("The display name of the User {} was updated successfully", userMatrixId);
+    } else {
+      if (response.statusCode() == 429) {
+        long sleepInMs = new JsonGeneratorImpl().createJsonObjectFromString(response.body())
+                                                .getElement("retry_after_ms")
+                                                .getLongValue();
+        LOG.warn("Too many requests on Matrix server, retrying to update the display name of the user {} after {}ms",
+                 userMatrixId,
+                 sleepInMs);
+        Thread.sleep(sleepInMs);
+        updateUserDisplayName(userMatrixId, displayName, token);
+      } else {
+        throw new RuntimeException("Error Updating the display name of the user %s, Matrix server returned HTTP %s error %s".formatted(userMatrixId,
+                                                                                                                                       String.valueOf(response.statusCode()),
+                                                                                                                                       response.body()));
+      }
+    }
+
+  }
+
+  /**
+   * Saves the user account
+   * 
+   * @param user the User
+   * @param matrixUserId the corresponding matrix ID
+   * @param isNew if the user account is one
+   * @param token the access token
+   * @param isEnableUserOperation is this an operation to enable/disable the user
+   *          on Matrix
+   * @return the user Matrix ID
+   */
+
+  public String saveUserAccount(User user, String matrixUserId, boolean isNew, String token, boolean isEnableUserOperation) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -384,13 +370,13 @@ public class MatrixHttpClient {
     }
   }
 
-  private static String hmacUserProperties(String nonce, String userName, String password, boolean isAdmin) {
+  private String hmacUserProperties(String nonce, String userName, String password, boolean isAdmin) {
     String userProperties = nonce + "\0" + userName + "\0" + password + "\0" + (isAdmin ? "admin" : "notadmin");
     return new HmacUtils(HmacAlgorithms.HMAC_SHA_1,
                          PropertyManager.getProperty(SHARED_SECRET_REGISTRATION)).hmacHex(userProperties);
   }
 
-  private static String getRegistrationNonce(String accessToken) {
+  private String getRegistrationNonce(String accessToken) {
     String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_synapse/admin/v1/register";
     try {
       HttpResponse<String> response = sendHttpGetRequest(url, accessToken);
@@ -410,7 +396,7 @@ public class MatrixHttpClient {
     }
   }
 
-  public static String disableAccount(String userName, boolean eraseData, String token) {
+  public String disableAccount(String userName, boolean eraseData, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -439,7 +425,7 @@ public class MatrixHttpClient {
     }
   }
 
-  public static String renameRoom(String roomId, String newRoomName, String token) {
+  public String renameRoom(String roomId, String newRoomName, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -479,7 +465,7 @@ public class MatrixHttpClient {
    * @param invitationMessage a custom invitation message
    * @return
    */
-  public static boolean inviteUserToRoom(String roomId, String userMatrixId, String invitationMessage, String token) {
+  public boolean inviteUserToRoom(String roomId, String userMatrixId, String invitationMessage, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -519,7 +505,7 @@ public class MatrixHttpClient {
    * @param userMatrixId the Matrix id of the user
    * @param raisonMessage the raison message
    */
-  public static void kickUserFromRoom(String roomId, String userMatrixId, String raisonMessage, String token) {
+  public void kickUserFromRoom(String roomId, String userMatrixId, String raisonMessage, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -557,7 +543,7 @@ public class MatrixHttpClient {
    * @param matrixIdOfUser the ID of the user of Matrix
    * @return Boolean true if operation succeeded
    */
-  public static boolean joinUserToRoom(String matrixRoomId, String matrixIdOfUser, String token) {
+  public boolean joinUserToRoom(String matrixRoomId, String matrixIdOfUser, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -609,7 +595,7 @@ public class MatrixHttpClient {
    * @return Boolean true if succeeded
    */
 
-  public static boolean makeUserAdminInRoom(String matrixRoomId, String matrixIdOfUser, String token) {
+  public boolean makeUserAdminInRoom(String matrixRoomId, String matrixIdOfUser, String token) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -647,9 +633,8 @@ public class MatrixHttpClient {
    * @param matrixRoomId
    * @return MatrixRoomPermissions object containing settings of the room
    */
-  public static MatrixRoomPermissions getRoomSettings(String matrixRoomId, String accessToken) throws IOException,
-                                                                                               InterruptedException,
-                                                                                               JsonException {
+  public MatrixRoomPermissions getRoomSettings(String matrixRoomId,
+                                               String accessToken) throws IOException, InterruptedException, JsonException {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -676,7 +661,9 @@ public class MatrixHttpClient {
    * @param matrixRoomId the Id of the room
    * @return MatrixRoomPermissions updated room settings
    */
-  public static String updateRoomSettings(String matrixRoomId, MatrixRoomPermissions roomSettings, String accessToken) throws IOException, InterruptedException, JsonException {
+  public String updateRoomSettings(String matrixRoomId,
+                                   MatrixRoomPermissions roomSettings,
+                                   String accessToken) throws IOException, InterruptedException, JsonException {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -699,7 +686,7 @@ public class MatrixHttpClient {
     }
   }
 
-  public static String uploadFile(String fileName, String mimeType, byte[] imageBytes, String accessToken) {
+  public String uploadFile(String fileName, String mimeType, byte[] imageBytes, String accessToken) {
     if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
@@ -731,7 +718,7 @@ public class MatrixHttpClient {
    * @param avatarURL the Avatar URL on
    * @return true if succeeded otherwise false
    */
-  public static boolean updateRoomAvatar(String matrixRoomId, String avatarURL, String accessToken) {
+  public boolean updateRoomAvatar(String matrixRoomId, String avatarURL, String accessToken) {
     String fullRoomId = matrixRoomId + ":" + PropertyManager.getProperty(MATRIX_SERVER_NAME);
     String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_matrix/client/v3/rooms/"
         + URLEncoder.encode(fullRoomId, StandardCharsets.UTF_8) + "/state/m.room.avatar/";
@@ -773,7 +760,7 @@ public class MatrixHttpClient {
    * @param avatarURL the avatar URL on Matrix
    * @return true if updated, false otherwise
    */
-  public static boolean updateUserAvatar(String userMatrixId, String avatarURL, String accessToken) {
+  public boolean updateUserAvatar(String userMatrixId, String avatarURL, String accessToken) {
     String fullMatrixUserId = "@%s:%s".formatted(userMatrixId, PropertyManager.getProperty(MATRIX_SERVER_NAME));
     String url =
                PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_matrix/client/v3/profile/" + fullMatrixUserId + "/avatar_url";
@@ -817,7 +804,7 @@ public class MatrixHttpClient {
    * @param description the updated description
    * @return true if the operation is successful, false otherwise
    */
-  public static boolean updateRoomDescription(String matrixRoomId, String description, String accessToken) {
+  public boolean updateRoomDescription(String matrixRoomId, String description, String accessToken) {
     String fullRoomId = matrixRoomId + ":" + PropertyManager.getProperty(MATRIX_SERVER_NAME);
     String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_matrix/client/v3/rooms/"
         + URLEncoder.encode(fullRoomId, StandardCharsets.UTF_8) + "/state/m.room.topic/";
@@ -860,7 +847,7 @@ public class MatrixHttpClient {
    * @param accessToken the access token
    * @return boolean True if the deletion is successful otherwise False
    */
-  public static boolean deleteRoom(String matrixRoomId, String accessToken) {
+  public boolean deleteRoom(String matrixRoomId, String accessToken) {
     String fullRoomId = matrixRoomId + ":" + PropertyManager.getProperty(MATRIX_SERVER_NAME);
     String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_synapse/admin/v1/rooms/"
         + URLEncoder.encode(fullRoomId, StandardCharsets.UTF_8);
@@ -892,7 +879,7 @@ public class MatrixHttpClient {
    * @param userName the user identifier
    * @return String the cleaned username
    */
-  public static String cleanMatrixUsername(String userName) {
+  public String cleanMatrixUsername(String userName) {
     String matrixAllowedCharacters = "_-./=+";
     StringBuilder formattedMatrixUserId = new StringBuilder();
     if (StringUtils.isNotBlank(userName)) {
@@ -909,5 +896,26 @@ public class MatrixHttpClient {
       }
     }
     return formattedMatrixUserId.toString();
+  }
+
+  public String getUserDisplayName(String userMatrixId,
+                                   String matrixAccessToken) throws IOException, InterruptedException, JsonException {
+    if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
+      throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
+    }
+    String encodedUserMatrixId = URLEncoder.encode(userMatrixId, StandardCharsets.UTF_8);
+
+    String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_matrix/client/v3/profile/" + encodedUserMatrixId
+        + "/displayname";
+
+    HttpResponse<String> response = sendHttpGetRequest(url, matrixAccessToken);
+    if (response.statusCode() >= 200 && response.statusCode() < 300) {
+      return new JsonGeneratorImpl().createJsonObjectFromString(response.body()).getElement("displayname").getStringValue();
+    } else {
+      throw new RuntimeException("Error Updating the display name of the user %s, Matrix server returned HTTP %s error %s".formatted(userMatrixId,
+                                                                                                                                     String.valueOf(response.statusCode()),
+                                                                                                                                     response.body()));
+    }
+
   }
 }

--- a/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePlugin.java
@@ -25,26 +25,30 @@ import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
 
 public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
 
-  private static final Log LOG                = ExoLogger.getExoLogger(MatrixRoomAndAccountsUpgradePlugin.class);
+  private static final Log    LOG                = ExoLogger.getExoLogger(MatrixRoomAndAccountsUpgradePlugin.class);
 
-  private SpaceService     spaceService;
+  private SpaceService        spaceService;
 
-  private MatrixService    matrixService;
+  private MatrixService       matrixService;
 
-  private IdentityManager  identityManager;
+  private IdentityManager     identityManager;
 
-  private int              SPACES_THRESHOLD   = 20;
+  private OrganizationService organizationService;
 
-  private int              LOADED_USERS_COUNT = 50;
+  private int                 SPACES_THRESHOLD   = 20;
+
+  private int                 LOADED_USERS_COUNT = 50;
 
   public MatrixRoomAndAccountsUpgradePlugin(InitParams initParams,
                                             SpaceService spaceService,
                                             MatrixService matrixService,
+                                            OrganizationService organizationService,
                                             IdentityManager identityManager) {
     super(initParams);
     this.spaceService = spaceService;
     this.matrixService = matrixService;
     this.identityManager = identityManager;
+    this.organizationService = organizationService;
   }
 
   @Override
@@ -92,7 +96,7 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
             ignoredSpaces++;
             LOG.debug("The space {} has already a room with Id {}", space.getDisplayName(), roomId);
           }
-          if(StringUtils.isNotBlank(roomId)) {
+          if (StringUtils.isNotBlank(roomId)) {
             matrixService.updateRoomAvatar(space, roomId);
           }
         }
@@ -120,9 +124,6 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
   private void synchronizeUsers() {
     LOG.info("Start:: create Matrix accounts for users");
     long startupTime = System.currentTimeMillis();
-    IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-    MatrixService matrixService = CommonsUtils.getService(MatrixService.class);
-    OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
 
     int checkedUsers = 0;
     int usersCount = 0;
@@ -159,16 +160,16 @@ public class MatrixRoomAndAccountsUpgradePlugin extends UpgradeProductPlugin {
           if (StringUtils.isBlank(userMatrixId)) {
             userMatrixId = matrixService.saveUserAccount(user, true, false);
           }
-          if(StringUtils.isNotBlank(userMatrixId)) {
+          if (StringUtils.isNotBlank(userMatrixId)) {
             // Update user avatar
             matrixService.updateUserAvatar(userProfile, userMatrixId);
 
             // Add user to spaces already sync with Matrix
             ListAccess<Space> userSpaces = spaceService.getMemberSpaces(user.getUserName());
             Space[] spaceArray = userSpaces.load(0, userSpaces.getSize());
-            for(Space space : spaceArray) {
+            for (Space space : spaceArray) {
               String spaceRoomId = matrixService.getRoomBySpace(space);
-              if(StringUtils.isNotBlank(spaceRoomId)) {
+              if (StringUtils.isNotBlank(spaceRoomId)) {
                 matrixService.joinUserToRoom(spaceRoomId, userMatrixId);
               }
             }

--- a/services/src/test/java/MatrixUtilsTest.java
+++ b/services/src/test/java/MatrixUtilsTest.java
@@ -5,6 +5,7 @@ import org.exoplatform.services.organization.idm.UserImpl;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.util.Date;
@@ -19,7 +20,9 @@ import static org.junit.Assert.*;
 
 public class MatrixUtilsTest {
 
-  private String access_token = "syt_ZXhv_BDVYgRelgkgjGduvVCyz_1iXdtf";
+  private String   access_token     = "syt_ZXhv_BDVYgRelgkgjGduvVCyz_1iXdtf";
+
+  MatrixHttpClient matrixHttpClient = new MatrixHttpClient();
 
   @Before
   public void setUp() {
@@ -34,7 +37,7 @@ public class MatrixUtilsTest {
     user.setEmail("test@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    MatrixHttpClient.createUserAccount(user, access_token);
+    matrixHttpClient.createUserAccount(user, access_token);
   }
 
   public void testSaveUserAccount() {
@@ -43,7 +46,7 @@ public class MatrixUtilsTest {
     user.setEmail("test@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    MatrixHttpClient.saveUserAccount(user, user.getUserName(), true, access_token, false);
+    matrixHttpClient.saveUserAccount(user, user.getUserName(), true, access_token, false);
   }
 
   public void testDisableUserAccount() {
@@ -52,18 +55,18 @@ public class MatrixUtilsTest {
     user.setEmail("test" + randomKey + "@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    String username = MatrixHttpClient.saveUserAccount(user, user.getUserName(), true, access_token, false);
-    MatrixHttpClient.disableAccount(username, false, access_token);
+    String username = matrixHttpClient.saveUserAccount(user, user.getUserName(), true, access_token, false);
+    matrixHttpClient.disableAccount(username, false, access_token);
   }
 
   public void testRenameSpace() {
     String roomId = null;
     try {
-      roomId = MatrixHttpClient.createRoom("new room", "new room description", access_token);
+      roomId = matrixHttpClient.createRoom("new room", "new room description", access_token);
     } catch (Exception e) {
       // nothing
     }
-    assertNotNull(MatrixHttpClient.renameRoom(roomId, "new room renamed" + new Date().getTime(), access_token));
+    assertNotNull(matrixHttpClient.renameRoom(roomId, "new room renamed" + new Date().getTime(), access_token));
   }
 
   public void testInviteUser() throws Exception {
@@ -72,9 +75,9 @@ public class MatrixUtilsTest {
     user.setEmail("test" + randomKey + "@exo.com");
     user.setFirstName("test " + randomKey);
     user.setLastName("User");
-    String invitee = MatrixHttpClient.saveUserAccount(user, user.getUserName(), true, access_token, false);
-    String roomId = MatrixHttpClient.createRoom("Football game", "Description of Football team", access_token);
-    MatrixHttpClient.inviteUserToRoom(roomId, invitee, "Welcome to Football game room !", access_token);
+    String invitee = matrixHttpClient.saveUserAccount(user, user.getUserName(), true, access_token, false);
+    String roomId = matrixHttpClient.createRoom("Football game", "Description of Football team", access_token);
+    matrixHttpClient.inviteUserToRoom(roomId, invitee, "Welcome to Football game room !", access_token);
   }
 
   /*
@@ -83,27 +86,22 @@ public class MatrixUtilsTest {
    */
   public void testKickUser() {
     String roomId = "!rYdqPkQhIzNWyVPDFX";
-    MatrixHttpClient.kickUserFromRoom(roomId, "@testuser1:matrix.exo.tn", "Talking too much!", access_token);
+    matrixHttpClient.kickUserFromRoom(roomId, "@testuser1:matrix.exo.tn", "Talking too much!", access_token);
   }
 
-  public void updateRoomSettings() {
+  public void updateRoomSettings() throws JsonException, IOException, InterruptedException {
     String roomId = "!rYdqPkQhIzNWyVPDFX";
-    MatrixRoomPermissions settings = null;
-    try {
-      settings = MatrixHttpClient.getRoomSettings(roomId, access_token);
-      settings.setInvite("0");
-      String updateEventId = MatrixHttpClient.updateRoomSettings(roomId, settings, access_token);
-    } catch (IOException | InterruptedException | JsonException e) {
-      fail();
-    }
+    MatrixRoomPermissions settings = matrixHttpClient.getRoomSettings(roomId, access_token);
+    settings.setInvite("0");
+    String updateEventId = matrixHttpClient.updateRoomSettings(roomId, settings, access_token);
   }
 
   public void updateRoomAvatar() {
     try {
       String roomId = "!HaTqHwWINwoSoIGfZx";
       byte[] resource = getClass().getClassLoader().getResourceAsStream("meeds.png").readAllBytes();
-      String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
-      boolean success = MatrixHttpClient.updateRoomAvatar(roomId, imageStored, access_token);
+      String imageStored = matrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
+      boolean success = matrixHttpClient.updateRoomAvatar(roomId, imageStored, access_token);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -114,8 +112,8 @@ public class MatrixUtilsTest {
       String roomId = "@root:matrix.exo.tn";
       int randomInt = new Random().nextInt(3);
       byte[] resource = getClass().getClassLoader().getResourceAsStream("avatar" + randomInt + ".png").readAllBytes();
-      String imageStored = MatrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
-      assertTrue(MatrixHttpClient.updateUserAvatar(roomId, imageStored, access_token));
+      String imageStored = matrixHttpClient.uploadFile("image.png", "image/png", resource, access_token);
+      assertTrue(matrixHttpClient.updateUserAvatar(roomId, imageStored, access_token));
     } catch (IOException e) {
       fail();
     }
@@ -126,7 +124,7 @@ public class MatrixUtilsTest {
     String[] usernames = new String[] { "Samueâl", "fre@d", "Shazia", "gorkef/",
         "²&é\"'(-è_çà)=²1234567890°+'azertyuiopqsdfghjklmù*^$wxcvbn,;:!?./§%µ¨£<>²&~#{[|`\\^@]}" };
     for (String username : usernames) {
-      String result = MatrixHttpClient.cleanMatrixUsername(username);
+      String result = matrixHttpClient.cleanMatrixUsername(username);
       assertNotNull(result);
     }
   }
@@ -134,7 +132,7 @@ public class MatrixUtilsTest {
   public void testDeleteSpace() throws Exception {
     long currentTime = System.currentTimeMillis();
     String matrixRoomId =
-                        MatrixHttpClient.createRoom("test space" + currentTime, "test description " + currentTime, access_token);
-    MatrixHttpClient.deleteRoom(matrixRoomId, access_token);
+                        matrixHttpClient.createRoom("test space" + currentTime, "test description " + currentTime, access_token);
+    matrixHttpClient.deleteRoom(matrixRoomId, access_token);
   }
 }

--- a/services/src/test/java/io/meeds/chat/MatrixBaseTest.java
+++ b/services/src/test/java/io/meeds/chat/MatrixBaseTest.java
@@ -1,0 +1,40 @@
+package io.meeds.chat;
+
+import io.meeds.kernel.test.AbstractSpringTest;
+import io.meeds.kernel.test.KernelExtension;
+import io.meeds.spring.AvailableIntegration;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static io.meeds.chat.service.utils.MatrixConstants.*;
+
+@ExtendWith({ SpringExtension.class, KernelExtension.class })
+@SpringBootApplication(scanBasePackages = { MatrixBaseTest.MODULE_NAME, AvailableIntegration.KERNEL_TEST_MODULE,
+    AvailableIntegration.JPA_MODULE, AvailableIntegration.LIQUIBASE_MODULE, AvailableIntegration.WEB_MODULE, })
+@EnableJpaRepositories(basePackages = MatrixBaseTest.MODULE_NAME)
+@TestPropertySource(properties = { "spring.liquibase.change-log=" + MatrixBaseTest.CHANGELOG_PATH,
+    "spring.profiles.active=matrix", })
+@ConfiguredBy({ @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
+    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/matrix-test-configuration.xml"), })
+public class MatrixBaseTest extends AbstractSpringTest {
+
+  public static final String MODULE_NAME    = "io.meeds.chat";
+
+  public static final String CHANGELOG_PATH = "classpath:db/changelog/matrix-rdbms.db.changelog-master.xml";
+
+  @BeforeAll
+  static void beforeAll() {
+    PropertyManager.setProperty(MATRIX_JWT_SECRET, "ThisIsAJWTSecretOfMatrixForTestingPurposes");
+    PropertyManager.setProperty(MATRIX_SERVER_URL, "https://matrix.exo.tn");
+    PropertyManager.setProperty(MATRIX_SERVER_NAME, "matrix.exo.tn");
+  }
+}

--- a/services/src/test/java/io/meeds/chat/service/MatrixServiceTest.java
+++ b/services/src/test/java/io/meeds/chat/service/MatrixServiceTest.java
@@ -1,0 +1,42 @@
+package io.meeds.chat.service;
+
+import io.meeds.chat.MatrixBaseTest;
+import io.meeds.chat.service.utils.MatrixHttpClient;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.ws.frameworks.json.impl.JsonException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.io.IOException;
+
+import static io.meeds.chat.service.utils.MatrixConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@SpringJUnitConfig(MatrixBaseTest.class)
+class MatrixServiceTest extends MatrixBaseTest {
+
+  @MockBean
+  MatrixHttpClient matrixHttpClient;
+
+  @Autowired
+  MatrixService matrixService;
+
+  @Test
+  void init() {
+    try {
+      this.matrixService.init();
+    } catch (Exception e) {
+      fail();
+    }
+  }
+
+  @Test
+  void updateUserDisplayName() {
+  }
+}

--- a/services/src/test/java/io/meeds/chat/service/utils/MatrixHttpClientTest.java
+++ b/services/src/test/java/io/meeds/chat/service/utils/MatrixHttpClientTest.java
@@ -1,6 +1,8 @@
 package io.meeds.chat.service.utils;
 
 import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.impl.UserImpl;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,32 +12,35 @@ import org.mockito.MockedStatic;
 import java.io.IOException;
 import java.net.http.HttpResponse;
 
-import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_SERVER_URL;
+import static io.meeds.chat.service.utils.MatrixConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 class MatrixHttpClientTest {
 
-  MockedStatic<MatrixHttpClient> MATRIX_HTTP_CLIENT;
+  MockedStatic<HTTPHelper> MATRIX_HTTP_HELPER;
 
-  String                         jwtToken = "ThisIsAJWTToken";
+  String                   jwtToken         = "ThisIsAJWTToken";
 
-  HttpResponse<String>           response;
+  String                   accessToken      = "ThisIsAnAccessTokenForUser";
+
+  HttpResponse<String>     responseOK;
+
+  HttpResponse<String>     responseTooManyRequests;
+
+  MatrixHttpClient         matrixHttpClient = new MatrixHttpClient();
 
   @Test
   void getAdminAccessToken() throws JsonException, IOException, InterruptedException {
-    PropertyManager.setProperty(MATRIX_SERVER_URL, "http://matrix:8008");
-
     // response OK
-    when(response.statusCode()).thenReturn(200);
-    when(response.body()).thenReturn("{\"access_token\":\"thisIsAnAccessToken\"}");
+    when(responseOK.statusCode()).thenReturn(200);
+    when(responseOK.body()).thenReturn("{\"access_token\":\"thisIsAnAccessToken\"}");
 
-    MATRIX_HTTP_CLIENT.when(() -> MatrixHttpClient.sendHttpPostRequest(anyString(), anyString(), anyString()))
-            .thenReturn(response);
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString())).thenReturn(responseOK);
     String result = "";
     try {
-      result = MatrixHttpClient.getAdminAccessToken(jwtToken);
+      result = matrixHttpClient.getAdminAccessToken(jwtToken);
     } catch (Exception e) {
       fail();
       throw e;
@@ -52,10 +57,10 @@ class MatrixHttpClientTest {
     when(response2.statusCode()).thenReturn(200);
     when(response2.body()).thenReturn("{\"access_token\":\"thisIsAnAccessToken\"}");
 
-    MATRIX_HTTP_CLIENT.when(() -> MatrixHttpClient.sendHttpPostRequest(anyString(), anyString(), anyString()))
-            .thenReturn(response1, response2);
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString()))
+                      .thenReturn(response1, response2);
     try {
-      result = MatrixHttpClient.getAdminAccessToken(jwtToken);
+      result = matrixHttpClient.getAdminAccessToken(jwtToken);
     } catch (Exception e) {
       fail();
       throw e;
@@ -68,13 +73,207 @@ class MatrixHttpClientTest {
 
   @BeforeEach
   void setUp() {
-    response = mock(HttpResponse.class);
-    MATRIX_HTTP_CLIENT = mockStatic(MatrixHttpClient.class);
-    MATRIX_HTTP_CLIENT.when(() -> MatrixHttpClient.getAdminAccessToken(anyString())).thenCallRealMethod();
+    PropertyManager.setProperty(MATRIX_SERVER_URL, "http://matrix:8008");
+    PropertyManager.setProperty(MATRIX_SERVER_NAME, "matrix.exo.com");
+    PropertyManager.setProperty(SHARED_SECRET_REGISTRATION, "sharedSecretRegistration");
+    MATRIX_HTTP_HELPER = mockStatic(HTTPHelper.class);
+    responseOK = mock(HttpResponse.class);
+    when(responseOK.statusCode()).thenReturn(200);
+
+    responseTooManyRequests = mock(HttpResponse.class);
+    when(responseTooManyRequests.statusCode()).thenReturn(429);
+    when(responseTooManyRequests.body()).thenReturn("{\"retry_after_ms\":\"120\"}");
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpGetRequest(anyString(), anyString())).thenReturn(responseOK);
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString())).thenReturn(responseOK);
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString(), any()))
+                      .thenReturn(responseOK);
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString())).thenReturn(responseOK);
+
   }
 
   @AfterEach
   void tearDown() {
-    MATRIX_HTTP_CLIENT.close();
+    MATRIX_HTTP_HELPER.close();
+  }
+
+  @Test
+  void updateUserDisplayName() {
+    // response OK
+    try {
+      matrixHttpClient.updateUserDisplayName("@user:matrix.server.com", "Chat Bot", accessToken);
+    } catch (Exception e) {
+      fail();
+    }
+
+    // response 429
+    HttpResponse response1 = mock(HttpResponse.class);
+    when(response1.statusCode()).thenReturn(429);
+    when(response1.body()).thenReturn("{\"retry_after_ms\":\"120\"}");
+
+    HttpResponse response2 = mock(HttpResponse.class);
+    when(response2.statusCode()).thenReturn(200);
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString()))
+                      .thenReturn(response1, response2);
+    try {
+      matrixHttpClient.updateUserDisplayName("@user:matrix.server.com", "Chat Bot", accessToken);
+    } catch (Exception e) {
+      fail();
+    }
+    verify(response1, times(1)).body();
+    verify(response2, times(0)).body();
+
+  }
+
+  @Test
+  void getUserDisplayName() throws JsonException, IOException, InterruptedException {
+    // response OK
+    when(responseOK.body()).thenReturn("{\"displayname\":\"Chat Bot\"}");
+
+    String displayName = matrixHttpClient.getUserDisplayName("@user:matrix.server.com", accessToken);
+    assertNotNull(displayName);
+    assertEquals("Chat Bot", displayName);
+  }
+
+  @Test
+  void authenticateUser() {
+    when(responseOK.body()).thenReturn("{\"access_token\":\"Access token for ali\"}");
+
+    String result = null;
+    try {
+      result = matrixHttpClient.authenticateUser("ali", "password");
+      assertNotNull(result);
+      assertEquals("Access token for ali", result);
+      verify(responseOK, times(1)).body();
+    } catch (Exception e) {
+      fail();
+    }
+    // Error HTTP 429 : too many requests
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString()))
+                      .thenReturn(responseTooManyRequests, responseOK);
+    try {
+      result = matrixHttpClient.authenticateUser("ali", "password");
+
+      assertNotNull(result);
+      assertEquals("Access token for ali", result);
+      verify(responseTooManyRequests, times(1)).body();
+      verify(responseOK, times(2)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
+
+  }
+
+  @Test
+  void createRoom() {
+    when(responseOK.body()).thenReturn("{\"room_id\":\"!RoomIdentifier:matrix.exo.com\"}");
+
+    String result = null;
+    try {
+      result = matrixHttpClient.createRoom("Internal Communication",
+                                           "Discussion room for planning internal news and announcements communication",
+                                           accessToken);
+      assertNotNull(result);
+      assertEquals("!RoomIdentifier", result);
+      verify(responseOK, times(1)).body();
+    } catch (Exception e) {
+      fail();
+    }
+    // Error HTTP 429 : too many requests
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString()))
+                      .thenReturn(responseTooManyRequests, responseOK);
+    try {
+      result = matrixHttpClient.createRoom("Internal Communication",
+                                           "Discussion room for planning internal news and announcements communication",
+                                           accessToken);
+
+      assertNotNull(result);
+      assertEquals("!RoomIdentifier", result);
+      verify(responseTooManyRequests, times(1)).body();
+      verify(responseOK, times(2)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
+
+  }
+
+  @Test
+  void createUserAccount() {
+    when(responseOK.body()).thenReturn("{\"user_id\":\"@harun:matrix.exo.com\"}");
+
+    HttpResponse nonceResponse = mock(HttpResponse.class);
+    when(nonceResponse.statusCode()).thenReturn(200);
+    when(nonceResponse.body()).thenReturn("{\"nonce\":\"ThisIsANonce\"}");
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpGetRequest(anyString(), anyString())).thenReturn(nonceResponse);
+
+    User user = new UserImpl("harun");
+    String result = null;
+
+      result = matrixHttpClient.createUserAccount(user, accessToken);
+      assertNotNull(result);
+      assertEquals("@harun:matrix.exo.com", result);
+      verify(responseOK, times(1)).body();
+
+  }
+
+  @Test
+  void testUpdateUserDisplayName() {
+  }
+
+  @Test
+  void saveUserAccount() {
+  }
+
+  @Test
+  void disableAccount() {
+  }
+
+  @Test
+  void renameRoom() {
+  }
+
+  @Test
+  void inviteUserToRoom() {
+  }
+
+  @Test
+  void kickUserFromRoom() {
+  }
+
+  @Test
+  void joinUserToRoom() {
+  }
+
+  @Test
+  void makeUserAdminInRoom() {
+  }
+
+  @Test
+  void getRoomSettings() {
+  }
+
+  @Test
+  void updateRoomSettings() {
+  }
+
+  @Test
+  void uploadFile() {
+  }
+
+  @Test
+  void updateRoomAvatar() {
+  }
+
+  @Test
+  void updateUserAvatar() {
+  }
+
+  @Test
+  void deleteRoom() {
   }
 }

--- a/services/src/test/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePluginTest.java
+++ b/services/src/test/java/io/meeds/chat/upgrade/MatrixRoomAndAccountsUpgradePluginTest.java
@@ -1,0 +1,91 @@
+package io.meeds.chat.upgrade;
+
+import io.meeds.chat.service.MatrixService;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.commons.utils.ListAccessImpl;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.organization.impl.UserImpl;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.SpaceFilter;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MatrixRoomAndAccountsUpgradePluginTest {
+
+  private SpaceService        spaceService;
+
+  private MatrixService       matrixService;
+
+  private IdentityManager     identityManager;
+
+  private OrganizationService organizationService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    spaceService = mock(SpaceService.class);
+    identityManager = mock(IdentityManager.class);
+    matrixService = mock(MatrixService.class);
+    organizationService = mock(OrganizationService.class);
+    UserHandler userHandler = mock(UserHandler.class);
+    ListAccess<User> usersListAccess = mock(ListAccess.class);
+    when(usersListAccess.getSize()).thenReturn(3);
+    User user1 = new UserImpl("user1");
+    User user2 = new UserImpl("user2");
+    User user3 = new UserImpl("user3");
+    Identity user1Identity = mock(Identity.class);
+    Identity user2Identity = mock(Identity.class);
+    Identity user3Identity = mock(Identity.class);
+    Profile user1Profile = mock(Profile.class);
+    Profile user2Profile = mock(Profile.class);
+    Profile user3Profile = mock(Profile.class);
+    when(user1Profile.getProperty(eq(USER_MATRIX_ID))).thenReturn("user1");
+    when(user2Profile.getProperty(eq(USER_MATRIX_ID))).thenReturn("user2");
+    when(user3Profile.getProperty(eq(USER_MATRIX_ID))).thenReturn("user3");
+    when(user1Identity.getProfile()).thenReturn(user1Profile);
+    when(user2Identity.getProfile()).thenReturn(user2Profile);
+    when(user3Identity.getProfile()).thenReturn(user3Profile);
+    when(usersListAccess.load(anyInt(), anyInt())).thenReturn(new User[] { user1, user2, user3 });
+    when(userHandler.findAllUsers()).thenReturn(usersListAccess);
+    when(organizationService.getUserHandler()).thenReturn(userHandler);
+
+    when(identityManager.getOrCreateUserIdentity(eq("user1"))).thenReturn(user1Identity);
+    when(identityManager.getOrCreateUserIdentity(eq("user2"))).thenReturn(user2Identity);
+    when(identityManager.getOrCreateUserIdentity(eq("user3"))).thenReturn(user3Identity);
+
+    Space space = new Space();
+    space.setMembers(new String[] {"user1", "user2", "user3"});
+    ListAccess<Space> spaces = mock(ListAccess.class);
+    when(spaces.getSize()).thenReturn(1);
+    when(spaces.load(anyInt(), anyInt())).thenReturn(new Space[] { space });
+    when(spaceService.getMemberSpaces(anyString())).thenReturn(spaces);
+
+    // spaces data
+    when(spaceService.getAllSpacesByFilter(any())).thenReturn(spaces);
+
+  }
+
+  @Test
+  void processUpgrade() {
+    InitParams initParams = new InitParams();
+    MatrixRoomAndAccountsUpgradePlugin matrixRoomAndAccountsUpgradePlugin =
+                                                                          new MatrixRoomAndAccountsUpgradePlugin(initParams,
+                                                                                                                 spaceService,
+                                                                                                                 matrixService,
+                                                                                                                 organizationService,
+                                                                                                                 identityManager);
+    matrixRoomAndAccountsUpgradePlugin.processUpgrade("versionSource", "versionTarget");
+  }
+}

--- a/services/src/test/resources/conf/portal/matrix-test-configuration.xml
+++ b/services/src/test/resources/conf/portal/matrix-test-configuration.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+</configuration>


### PR DESCRIPTION
The current code will check the property **meeds.matrix.user.display.name** if it is different than the current display name of the system integration user, it will update it. Default value will be set to **Chat bot**
The current code increases also the UT coverage