### PR TITLE
feat: return rooms even when related space is deleted - MEED-7702 - Meeds-io/MIP#163

### DIFF
--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -469,8 +469,12 @@ public class MatrixService {
       if(matrixRoom != null) {
         if(StringUtils.isNotBlank(matrixRoom.getSpaceId())) {
           Space space = spaceService.getSpaceById(matrixRoom.getSpaceId());
-          room.setName(space.getDisplayName());
-          room.setAvatarUrl(space.getAvatarUrl());
+          if(space != null) {
+            room.setName(space.getDisplayName());
+            room.setAvatarUrl(space.getAvatarUrl());
+          } else {
+            continue;
+          }
         } else {
           Identity identity = null;
           if(matrixRoom.getFirstParticipant().equals(currentUserName)) {
@@ -481,6 +485,8 @@ public class MatrixService {
           if(identity != null) {
             room.setName(identity.getProfile().getFullName());
             room.setAvatarUrl(identity.getProfile().getAvatarUrl());
+          } else {
+            continue;
           }
         }
       }


### PR DESCRIPTION
In some cases when a space is deleted and the synapse server is not up, the related room on Synapse won't be deleted and an error is thrown when returning the list of user rooms, the discussion drawer will be empty.
The fix checks for the nullity of spaces and returns the room without adding the extra information about the related space.