### PR TITLE
fix: update project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,22 @@
   </modules>
 
   <properties>
-    <addon.exo.ecms.version>7.0.x-SNAPSHOT</addon.exo.ecms.version>
+    <io.meeds.social.version>7.0.x-SNAPSHOT</io.meeds.social.version>
+    <io.meeds.pwa.version>7.0.x-SNAPSHOT</io.meeds.pwa.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.exoplatform.ecms</groupId>
-        <artifactId>ecms</artifactId>
-        <version>${addon.exo.ecms.version}</version>
+        <groupId>io.meeds.social</groupId>
+        <artifactId>social</artifactId>
+        <version>${io.meeds.social.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.meeds.pwa</groupId>
+        <artifactId>pwa</artifactId>
+        <version>${io.meeds.pwa.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Update project dependencies and remove eXo platform ones to rely on Meeds dependencies only.