### PR TITLE
fix: JWT token and related cookie should have the exact live time - meeds-8482 - Meeds-io/MIPs-163

### DIFF
--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -223,7 +223,7 @@ public class MatrixService {
    * @return String
    */
   public String getJWTSessionToken(String userNameOnMatrix) {
-    Date expirtaionDate = Date.from(Instant.now().plusSeconds(7 * 24 * 60 * 60)); // adds one week to the current instant
+    Date expirtaionDate = Date.from(Instant.now().plusSeconds(7 * 24 * 60 * 60L)); // adds one week to the current instant
     return Jwts.builder()
                .setSubject(userNameOnMatrix)
                .signWith(Keys.hmacShaKeyFor(PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes()))

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -58,6 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.*;
@@ -222,10 +223,11 @@ public class MatrixService {
    * @return String
    */
   public String getJWTSessionToken(String userNameOnMatrix) {
+    Date expirtaionDate = Date.from(Instant.now().plusSeconds(7 * 24 * 60 * 60)); // adds one week to the current instant
     return Jwts.builder()
                .setSubject(userNameOnMatrix)
                .signWith(Keys.hmacShaKeyFor(PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes()))
-               .setExpiration(Date.from(LocalDate.now().plusDays(7).atStartOfDay(ZoneId.systemDefault()).toInstant()))
+               .setExpiration(expirtaionDate)
                .compact();
 
   }


### PR DESCRIPTION
When creating the JWT token, the expiration was set to the start of the day after a week which is not equal to the expiration date of the cookie that will be at the exact date and time in one week. This fixes that by calculating exactly the time after a week .