### PR TITLE
fix: sort discussion with latest received message then natural order - MEED-8455 - Meeds-io/MIPs-163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <io.meeds.social.version>7.0.x-devx-SNAPSHOT</io.meeds.social.version>
-    <io.meeds.pwa.version>7.0.x-exo-SNAPSHOT</io.meeds.pwa.version>
+    <addon.meeds.pwa.version>7.0.x-exo-SNAPSHOT</addon.meeds.pwa.version>
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>
@@ -54,7 +54,7 @@
       <dependency>
         <groupId>io.meeds.pwa</groupId>
         <artifactId>pwa</artifactId>
-        <version>${io.meeds.pwa.version}</version>
+        <version>${addon.meeds.pwa.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <io.meeds.social.version>7.0.x-devx-SNAPSHOT</io.meeds.social.version>
-    <addon.meeds.pwa.version>7.0.x-exo-SNAPSHOT</addon.meeds.pwa.version>
+    <io.meeds.pwa.version>7.0.x-exo-SNAPSHOT</io.meeds.pwa.version>
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>
@@ -54,7 +54,7 @@
       <dependency>
         <groupId>io.meeds.pwa</groupId>
         <artifactId>pwa</artifactId>
-        <version>${addon.meeds.pwa.version}</version>
+        <version>${io.meeds.pwa.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -142,6 +142,7 @@
           updatedRoom.unreadMessages += 1;
           this.rooms.splice(updatedRoomIndex, 1);
           this.rooms.unshift(updatedRoom);
+          updatedRoom.updated = event.detail.origin_server_ts;
           if(event.detail.sender === localStorage.getItem('matrix_user_id')) {
             updatedRoom.lastMessage.content = this.$t('matrix.chat.lastMessage.pattern').replace('{0}',
                                               this.$t('matrix.words.you')).replace('{1}', event.detail.message);

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -324,7 +324,17 @@ export async function toRoomObject(rooms, currentMemberId) {
     myRooms.totalUnreadMessages += roomItem.unreadMessages;
     myRooms.rooms.push(roomItem);
   }
-  myRooms.rooms.sort((roomOne, roomTwo) => roomOne.updated <= roomTwo.updated);
+  myRooms.rooms.sort((roomOne, roomTwo) => {
+    if(roomOne.updated && roomTwo.updated) {
+      return roomOne.updated <= roomTwo.updated;
+    } else if(roomOne.updated) {
+      return -1;
+    } else if (roomTwo.updated) {
+      return 1;
+    } else {
+      return roomOne.name.localeCompare(roomTwo.name, undefined, {numeric: true, sensitivity: 'base'}); // Natural sorting using room names
+    }
+  });
   return myRooms;
 }
 


### PR DESCRIPTION
The discussion rooms are sorted by : 
1- latest room that received a new message is moved to the top
2- If there is no message yet, they are sorted with Natural sorting order