### PR TITLE
fix: sorting function ignored in some cases - MEED-8445 - Meeds-io/MIPs-163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -332,7 +332,7 @@ export async function toRoomObject(rooms, currentMemberId) {
   }
   myRooms.rooms.sort((roomOne, roomTwo) => {
     if(roomOne.updated && roomTwo.updated) {
-      return roomOne.updated <= roomTwo.updated;
+      return roomTwo.updated - roomOne.updated;
     } else if(roomOne.updated) {
       return -1;
     } else if (roomTwo.updated) {


### PR DESCRIPTION
Update the sorting rule to return the result of subtraction of the update dates of rooms instead of the result of comparison