### PR TITLE
 feat: Load more messages from history - MEED-8453 - Meeds-io/MIPs#163 

### DIFF
--- a/webapp/src/main/webapp/css/matrix.less
+++ b/webapp/src/main/webapp/css/matrix.less
@@ -202,3 +202,10 @@
 .mt-0-5 {
   margin-top: 2px !important;
 }
+
+#ChatDiscussionDrawer {
+  #chatMessagesContainer {
+    height: 100%;
+    overflow: auto;
+  }
+}

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -20,8 +20,31 @@
       </a>
     </template>
     <template slot="content">
-      <div class="d-flex flex-column">
-        <meeds-chat-message :id="'chat-message-' + i" :ref="'message' + i" :key="i" v-for="(message, i) in messages" :message="message" :previous-message="i > 0 && messages[i-1]" :next-message="messages[i+1] || {}" :room="room"/>
+      <div id="chatMessagesContainer">
+        <div
+          v-if="loadingNewMessages"
+          class="application-background-color application-border application-border-radius flex d-flex flex-column">
+          <v-progress-circular
+            color="primary"
+            size="20"
+            indeterminate
+            class="mx-auto my-5" />
+        </div>
+        <div
+          id="roomChatMessages"
+          class="d-flex flex-column"
+          @wheel="loadMoreMessages"
+          @scroll="loadMoreMessages">
+          <meeds-chat-message
+            :id="'chat-message-' + i"
+            :ref="'message' + i"
+            :key="i"
+            v-for="(message, i) in messages"
+            :message="message"
+            :previous-message="i > 0 && messages[i-1]"
+            :next-message="i < (messages.length - 1) && messages[i+1]"
+            :room="room"/>
+        </div>
       </div>
     </template>
     <template slot="footer">
@@ -39,6 +62,8 @@ export default {
       messages: [],
       room: {},
       loading: false,
+      loadingNewMessages: false,
+      hasMoreMessages: true,
     };
   },
   computed: {
@@ -77,8 +102,13 @@ export default {
     openDiscussion(e) {
       this.loading = true;
       this.room = e;
-      this.$matrixService.loadAllRoomMessages(this.room.id, false).then(resp => {
-        this.messages = resp;
+      this.$matrixService.loadRoomMessages(this.room.id).then(resp => {
+        if(!resp.chunk || !resp.chunk.length) {
+          this.hasMoreMessages = false;
+        }
+        this.messages = resp.chunk.reverse();
+        this.from = resp.start;
+        this.to = resp.end;
         this.$nextTick().then(() => {
           this.scrollToEnd();
         });
@@ -89,6 +119,7 @@ export default {
     },
     close(){
       this.messages = null;
+      this.hasMoreMessages = true;
       this.$refs.ChatDiscussionDrawer?.close();
     },
     messageReceived(event) {
@@ -111,6 +142,34 @@ export default {
           }
         }
       }, 100);
+    },
+    loadMoreMessages(e) {
+      const messagesDOMEl = document.getElementById('chatMessagesContainer');
+      console.log(messagesDOMEl.scrollTop);
+      if(this.loadingNewMessages || !this.hasMoreMessages || messagesDOMEl.scrollTop > 0) {
+        return;
+      }
+      this.loadingNewMessages = true;
+      const lastMessageId = this.messages[0].event_id;
+      setTimeout( () => {
+        this.$matrixService.loadRoomMessages(this.room.id, this.to).then(resp => {
+          // check if there is no more messages
+          if(!resp.chunk || !resp.chunk.length) {
+            this.hasMoreMessages = false;
+          }
+          this.messages = [...resp.chunk.reverse(), ...this.messages];
+          this.from = resp.start;
+          this.to = resp.end;
+        }).finally(() => {
+          this.$nextTick().then(() => {
+            document.getElementById(lastMessageId).scrollIntoView({
+              behavior: 'smooth'
+            });
+          });
+
+          this.loadingNewMessages = false;
+        });
+      }, 1000);
     }
   }
 };

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatMessage.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatMessage.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="chat-message-content">
-    <div v-if="!sameDateAs(message.origin_server_ts, previousMessage.origin_server_ts)" class="mb-5 text-font-small-size font-weight-bold text-center" :class="{ 'mt-5' : previousMessage }"> {{ formattedDate }} </div>
-    <div class="px-4" :class="{'mt-3' : message.sender !== previousMessage.sender}">
+    <div
+      v-if="!sameDateAs(message.origin_server_ts, previousMessage.origin_server_ts)"
+      class="mb-5 text-font-small-size font-weight-bold text-center"
+      :class="{ 'mt-5' : previousMessage }">
+      {{ formattedDate }}
+    </div>
+    <div
+      :id="message.event_id"
+      class="px-4"
+      :class="{'mt-3' : message.sender !== previousMessage.sender}"
+      >
       <div class="d-relative">
         <div class="avatar-of-user mt-3" v-if="displaySender">
           <a :href="profileUrl">
@@ -22,12 +31,12 @@
             <template #activator="{on, bind}">
               <div v-on="on"
                  v-bind="bind"
-                 v-if="displayTimestamp"
+                 v-show="displayTimestamp"
                  class="text-font-small-size chat-message-content-timestamp">
                 {{ formattedTimestamp }}
               </div>
             </template>
-            <date-format :value="timestamp" :format="dateFormat" />
+            <date-format :value="message.origin_server_ts" :format="dateFormat" />
           </v-tooltip>
         </div>
       </div>
@@ -57,7 +66,6 @@
     data() {
       return {
         sender: {},
-        timestamp: '',
         presenceClass: 'offline',
         dateFormat: {
           year: 'numeric',
@@ -70,7 +78,6 @@
     },
     created() {
       this.$matrixService.getUserByMatrixId(this.message.sender).then(sender => {
-        this.timestamp = new Date(this.message.origin_server_ts);
         this.sender = sender;
         this.$matrixService.getUserPresence(this.message.sender).then(status => {
           this.presenceClass = `matrix-status-${status}`;
@@ -82,14 +89,17 @@
     computed: {
       formattedTimestamp() {
         const now = new Date().getTime();
-        if(this.sameDateAs(this.timestamp, now) && this.sameTimeAs(this.timestamp, now) && !this.nextMessage.timestamp) {
+        if(this.sameDateAs(this.message.origin_server_ts, now) && !this.nextMessage.timestamp) {
           return this.$t('matrix.chat.time.now');
         }
-        const currentDate = new Date(this.timestamp);
-        return `${currentDate.getHours()}:${currentDate.getMinutes() < 9 && '0' + currentDate.getMinutes() || currentDate.getMinutes()}`;
+        const currentDate = new Date(this.message.origin_server_ts);
+        return currentDate.toLocaleTimeString(eXo.env.portal.language.replace('_', '-'), {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
       },
       formattedDate() {
-        return this.$matrixService.formatDate(this.timestamp, true);
+        return this.$matrixService.formatDate(this.message.origin_server_ts, true);
       },
       profileUrl() {
         return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${this.sender.remoteId}`;
@@ -122,10 +132,10 @@
         return this.previousMessage.sender !== this.message.sender && this.message.sender !== localStorage.getItem('matrix_user_id') && !this.room.directChat;
       },
       displayTimestamp() {
-        if(this.nextMessage) {
+        if(this.nextMessage && this.message.sender === this.nextMessage.sender) {
           const nextMessageDate = new Date(this.nextMessage.origin_server_ts);
           nextMessageDate.setSeconds(0,0);
-          const currentMessageDate = new Date(this.timestamp);
+          const currentMessageDate = new Date(this.message.origin_server_ts);
           currentMessageDate.setSeconds(0,0);
           return nextMessageDate.getTime() !== currentMessageDate.getTime();
         } else {

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -10,6 +10,7 @@ const MATRIX_SYNC_TIMEOUT = 30000;
 const MATRIX_ACTION_MESSAGE_RECEIVED = 'matrix-message-received';
 const PUSH_APP_ID = "exo.matrix.app";
 const PUSH_APP_DISPLAY_NAME = 'Meeds application';
+const MESSAGES_LOAD_LIMIT = 20;
 
 
 export function checkAuthenticationTypes() {
@@ -211,7 +212,7 @@ export function processEvents(response) {
         //message received in a room
         if(e.type === 'm.room.message') {
           if(e.content.msgtype === 'm.text') {
-            document.dispatchEvent(new CustomEvent('matrix-message-received', { detail: {roomId: roomId, sender: e.sender, message: e.content.body, origin_server_ts: e.origin_server_ts}}));
+            document.dispatchEvent(new CustomEvent('matrix-message-received', { detail: {roomId: roomId, sender: e.sender, message: e.content.body, origin_server_ts: e.origin_server_ts, event_id : e.event_id}}));
           }
         } // Joined a new room
         else if(e.type === 'm.room.member') {
@@ -257,7 +258,7 @@ export async function toRoomObject(rooms, currentMemberId) {
     const roomEvents = [...rooms[property].timeline.events, ...rooms[property].state.events];
     roomEvents.forEach(e => {
       if(e.type === 'm.room.create'){
-        roomItem.updated = e.origin_server_ts;
+        roomItem.created = e.origin_server_ts;
       }
       if(e.type === 'm.room.topic'){
         roomItem.topic = e.content.topic;
@@ -295,6 +296,7 @@ export async function toRoomObject(rooms, currentMemberId) {
           roomItem.lastMessage = {};
           roomItem.lastMessage.content = e.content.body;
           roomItem.lastMessage.sender = e.sender;
+          roomItem.lastMessage.eventId = e.event_id;
         }
       }
     });
@@ -325,7 +327,7 @@ export async function toRoomObject(rooms, currentMemberId) {
       roomItem.avatarUrl = DEFAULT_ROOM_AVATAR;
     }
     if(!roomItem.updated) {
-      roomItem.updated = new Date().getTime();
+      roomItem.updated = roomItem.created || new Date().getTime();
     }
     myRooms.totalUnreadMessages += roomItem.unreadMessages;
     myRooms.rooms.push(roomItem);
@@ -589,14 +591,14 @@ export function getUserByMatrixId(userIdOnMatrix) {
 export async function loadRoomMessages(roomId, from, to) {
   const filter = {types:['m.room.message'],};
   const formData = new FormData();
-  formData.append('limit', 50);
+  formData.append('limit', MESSAGES_LOAD_LIMIT);
   if(from) {
     formData.append('from', from);
   }
   if(to) {
     formData.append('to', to);
   }
-  formData.append('dir', 'f'); // f: chronological order, b: revers-chronological order
+  formData.append('dir', 'b'); // f: chronological order, b: revers-chronological order
   formData.append('filter', JSON.stringify(filter));
   const params = new URLSearchParams(formData).toString();
   if(!roomId.includes(":")) {
@@ -607,6 +609,12 @@ export async function loadRoomMessages(roomId, from, to) {
     headers: {
       'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
     },
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Load room messages : Response code indicates a server error', resp);
+    } else {
+      return resp.json();
+    }
   });
 }
 


### PR DESCRIPTION
This will add the possibility to load chat messages from the history and display them in the discussion drawer. the API supports loading messages by a predefined limit number that we set to 20 by default.
