### PR TITLE
fix: sort discussion with latest received message then natural order - MEED-8455 - Meeds-io/MIPs-163

### DIFF
--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -144,8 +144,7 @@ public class MatrixRest implements ResourceContainer {
     }
     Room directMessagingRoom = matrixService.getDirectMessagingRoom(firstParticipant, secondParticipant);
     if (directMessagingRoom != null) {
-      RoomEntity roomEntity = buildRoomEntityFromRoom(directMessagingRoom, currentUser);
-      return processRoom(roomEntity, currentUser);
+        return buildRoomEntityFromRoom(directMessagingRoom, currentUser);
     } else {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                                         "Could not find a room for participants %s and %s".formatted(firstParticipant,
@@ -159,17 +158,16 @@ public class MatrixRest implements ResourceContainer {
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
-  public RoomEntity getDirectMessagingRoom(HttpServletRequest request,
-                                           @RequestBody(description = "Matrix object to create", required = true)
-                                           @org.springframework.web.bind.annotation.RequestBody
-                                           Room room) {
+  public RoomEntity createDirectMessagingRoom(HttpServletRequest request,
+                                              @RequestBody(description = "Matrix object to create", required = true)
+                                              @org.springframework.web.bind.annotation.RequestBody
+                                              Room room) {
     if (StringUtils.isBlank(room.getFirstParticipant()) || StringUtils.isBlank(room.getSecondParticipant())) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "the ids of the participants should not be null");
     }
     try {
       String currentUserName = request.getRemoteUser();
-      return processRoom(buildRoomEntityFromRoom(matrixService.createDirectMessagingRoom(room), currentUserName),
-                                       currentUserName);
+      return buildRoomEntityFromRoom(matrixService.createDirectMessagingRoom(room), currentUserName);
     } catch (ObjectAlreadyExistsException objectAlreadyExists) {
       throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, objectAlreadyExists.getMessage());
     }
@@ -313,6 +311,26 @@ public class MatrixRest implements ResourceContainer {
     }
   }
 
+  @GetMapping("byRoomId")
+  @Secured("users")
+  @Operation(summary = "Get the room by Id", method = "GET", description = "Get the room by Id")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "404", description = "User not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
+  public ResponseEntity<RoomEntity> getRoomById(HttpServletRequest request,
+                                                WebRequest webRequest,
+                                                @Parameter(description = "The room Id")
+                                                @RequestParam(name = "roomId")
+                                                String roomId) {
+    String userName = request.getRemoteUser();
+    Room room = matrixService.getById(roomId);
+    if (!matrixService.canAccess(room, userName)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+    }
+    RoomEntity roomEntity = buildRoomEntityFromRoom(room, userName);
+    return ResponseEntity.ok().body(roomEntity);
+  }
+
   @GetMapping("userByMatrixId")
   @Secured("users")
   @Operation(summary = "Get the user Identity for the provided matrix user Id", method = "GET", description = "Get the user Identity for the provided matrix user Id")
@@ -394,8 +412,8 @@ public class MatrixRest implements ResourceContainer {
   private RoomEntity buildRoomEntityFromRoom(Room room, String currentUserName) {
     RoomEntity roomEntity = new RoomEntity();
     roomEntity.setId(room.getRoomId());
-    roomEntity.setSpaceId(room.getSpaceId());
     if (StringUtils.isNotBlank(room.getSpaceId())) {
+      roomEntity.setSpaceId(room.getSpaceId());
       roomEntity.setDirectChat(false);
       roomEntity.setSpaceId(room.getSpaceId());
     } else if (StringUtils.isNotBlank(room.getFirstParticipant()) && StringUtils.isNotBlank(room.getSecondParticipant())) {
@@ -406,6 +424,8 @@ public class MatrixRest implements ResourceContainer {
         roomEntity.setDmMemberId(room.getFirstParticipant());
       }
     }
+    // Update room entity with data from Meeds server
+    updateRoomEntity(roomEntity, currentUserName);
     return roomEntity;
   }
 
@@ -425,12 +445,12 @@ public class MatrixRest implements ResourceContainer {
     }
 
     for (RoomEntity room : roomList.getRooms()) {
-      processRoom(room, currentUserName);
+      updateRoomEntity(room, currentUserName);
     }
     return roomList;
   }
 
-  public RoomEntity processRoom(RoomEntity room, String currentUserName) {
+  private RoomEntity updateRoomEntity(RoomEntity room, String currentUserName) {
     // Update room information
     String roomId = room.getId().substring(0, room.getId().indexOf(":"));// remove server part
     Room matrixRoom = matrixService.getById(roomId);
@@ -441,6 +461,7 @@ public class MatrixRest implements ResourceContainer {
           room.setName(space.getDisplayName());
           room.setAvatarUrl(space.getAvatarUrl());
           room.setSpaceId(matrixRoom.getSpaceId());
+          room.setDirectChat(false);
         }
       } else if (StringUtils.isNotBlank(matrixRoom.getFirstParticipant())
           && StringUtils.isNotBlank(matrixRoom.getSecondParticipant())) {
@@ -455,6 +476,7 @@ public class MatrixRest implements ResourceContainer {
           room.setAvatarUrl(identity.getProfile().getAvatarUrl());
           room.setUserId(identity.getRemoteId());
           room.setIdentityId(identity.getId());
+          room.setDmMemberId(identity.getRemoteId());
         }
       }
     }
@@ -479,6 +501,11 @@ public class MatrixRest implements ResourceContainer {
         message.setContent(updatedContent);
         room.setLastMessage(new Message(updatedContent, identity.getProfile().getFullName()));
       }
+    }
+
+    // Add update Date
+    if(room.getUpdated() == 0) {
+      room.setUpdated(System.currentTimeMillis());
     }
     return room;
   }

--- a/services/src/main/java/io/meeds/chat/rest/model/RoomEntity.java
+++ b/services/src/main/java/io/meeds/chat/rest/model/RoomEntity.java
@@ -37,7 +37,7 @@ public class RoomEntity implements Serializable {
 
   private boolean      enabledUser;
 
-  private String       presence;
+  private String       presence = "offline"; //"online", "offline" or "unavailable"
 
   private boolean      directChat;
 

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -562,4 +562,19 @@ public class MatrixService {
     }
     return null;
   }
+
+  /**
+   * Checks if the user able to access the room
+   * @param room the room
+   * @param userName the username of the user
+   * @return true if he has access, false otherwise
+   */
+  public boolean canAccess(Room room, String userName) {
+    if(StringUtils.isBlank(room.getSpaceId())) {
+      return userName.equals(room.getFirstParticipant()) || userName.equals(room.getSecondParticipant());
+    } else {
+      Space space = spaceService.getSpaceById(room.getId());
+      return spaceService.canViewSpace(space, userName);
+    }
+  }
 }

--- a/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
+++ b/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
@@ -222,4 +222,52 @@ class MatrixRestTest {
             .param("userMatrixId", "@user:matrix.exo.tn"));
     response1.andExpect(status().isOk());
   }
+
+  @Test
+  void getRoomById() throws Exception {
+    String roomId = "!testRoomIdentifier:matrix.exo.tn";
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/byRoomId").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("roomId", roomId));
+    response.andExpect(status().isForbidden());
+
+    Room room = new Room();
+    room.setRoomId(roomId);
+    room.setSpaceId("1");
+
+    Space space = new Space();
+    space.setAvatarUrl("/avatar/of/the/space");
+    space.setDisplayName("Test space");
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+    when(matrixService.getById(eq(roomId))).thenReturn(room);
+    when(matrixService.canAccess(eq(room), anyString())).thenReturn(true);
+
+    ResultActions response1 = mockMvc.perform(get(REST_PATH + "/byRoomId").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("roomId", roomId));
+    response1.andExpect(status().isOk());
+  }
+
+
+  @Test
+  void getDirectMessagingRoom() throws Exception {
+    String roomId = "!testRoomIdentifier:matrix.exo.tn";
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/dmRoom").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("firstParticipant", "userOne")
+            .param("secondParticipant", "userTwo"));
+    response.andExpect(status().isNotFound());
+
+    Room room = new Room();
+    room.setRoomId(roomId);
+    room.setSpaceId(null);
+    room.setFirstParticipant("userOne");
+    room.setSecondParticipant("userTwo");
+    when(matrixService.getDirectMessagingRoom(eq("userOne"), eq("userTwo"))).thenReturn(room);
+    ResultActions response1 = mockMvc.perform(get(REST_PATH + "/dmRoom").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("firstParticipant", "userOne")
+            .param("secondParticipant", "userTwo"));
+    response1.andExpect(status().isOk());
+  }
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -20,7 +20,7 @@
     </div>
     <div class="ps-3 my-3">
       <div class="last-message-timestamp text-subtitle">
-        {{ getLastMessageTime(room) }}
+        {{ getUpdateTime(room) }}
       </div>
       <div class="pull-right text-font-small-size d-flex">
         <v-icon v-if="room.isMuted" size="16">fas fa-bell-slash</v-icon>
@@ -44,9 +44,6 @@
     mounted() {
     },
     computed : {
-      roomURL() {
-        return 'https://matrix.to/#/' + this.room.id + '?via=' + this.$root.$data.serverName;
-      },
       avatarBorderClass() {
         return this.room.directChat ? 'rounded-circle' : 'rounded-lg';
       },
@@ -61,7 +58,7 @@
       openRoom() {
         document.dispatchEvent(new CustomEvent(this.$chatConstants.ACTION_OPEN_CHAT_ROOM, { detail: this.room }));
       },
-      getLastMessageTime(room) {
+      getUpdateTime(room) {
         return this.$matrixService.formatDate(room.updated);
       },
       getUserPresence() {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -142,6 +142,7 @@
           updatedRoom.unreadMessages += 1;
           this.rooms.splice(updatedRoomIndex, 1);
           this.rooms.unshift(updatedRoom);
+          updatedRoom.updated = event.detail.origin_server_ts;
           if(event.detail.sender === localStorage.getItem('matrix_user_id')) {
             updatedRoom.lastMessage.content = this.$t('matrix.chat.lastMessage.pattern').replace('{0}',
                                               this.$t('matrix.words.you')).replace('{1}', event.detail.message);

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -224,10 +224,13 @@ export function processEvents(response) {
             room.members = [];
             room.members.push(member);
             room.id = roomId;
+            if(!room.updated) {
+              room.updated = new Date().getTime();
+            }
             if(localStorage.getItem('matrix_user_id') !== e.sender) {
-              room.name = e.content.displayname;
-              room.avatarUrl = e.content.avatar_url ? '/_matrix/media/v3/thumbnail/' + e.content.avatar_url.substring(6) + '?width=32&height=32&method=crop&allow_redirect=true': chatConstants.DEFAULT_ROOM_AVATAR;
-              document.dispatchEvent(new CustomEvent('matrix-joined-room', { detail: room }));
+              getRoomById(roomId).then(roomItem => {
+                document.dispatchEvent(new CustomEvent('matrix-joined-room', { detail: roomItem }));
+              });
             }
           }
         }
@@ -253,6 +256,9 @@ export async function toRoomObject(rooms, currentMemberId) {
     let members = [];
     const roomEvents = [...rooms[property].timeline.events, ...rooms[property].state.events];
     roomEvents.forEach(e => {
+      if(e.type === 'm.room.create'){
+        roomItem.updated = e.origin_server_ts;
+      }
       if(e.type === 'm.room.topic'){
         roomItem.topic = e.content.topic;
       }
@@ -319,12 +325,22 @@ export async function toRoomObject(rooms, currentMemberId) {
       roomItem.avatarUrl = DEFAULT_ROOM_AVATAR;
     }
     if(!roomItem.updated) {
-      roomItem.updated = 0;
+      roomItem.updated = new Date().getTime();
     }
     myRooms.totalUnreadMessages += roomItem.unreadMessages;
     myRooms.rooms.push(roomItem);
   }
-  myRooms.rooms.sort((roomOne, roomTwo) => roomOne.updated <= roomTwo.updated);
+  myRooms.rooms.sort((roomOne, roomTwo) => {
+    if(roomOne.updated && roomTwo.updated) {
+      return roomTwo.updated - roomOne.updated;
+    } else if(roomOne.updated) {
+      return -1;
+    } else if (roomTwo.updated) {
+      return 1;
+    } else {
+      return roomOne.name.localeCompare(roomTwo.name, undefined, {numeric: true, sensitivity: 'base'}); // Natural sorting using room names
+    }
+  });
   return myRooms;
 }
 
@@ -359,7 +375,7 @@ export function getDMRoom(firstParticipant, secondParticipant, serverName) {
                 return getDMRoomsAccountData(firstParticipant).then(accountData =>
                   updateDMRoomsAccountData(`${localStorage.getItem('matrix_user_id')}`, accountData)
                   ).then(dataResp => {
-                    document.dispatchEvent(new CustomEvent('chat-load-chat-rooms'));
+                    //document.dispatchEvent(new CustomEvent('chat-load-chat-rooms'));
                     return createdRoom.json();
                   });
               }
@@ -380,6 +396,19 @@ export function openDMRoom(firstParticipant, secondParticipant, matrixServerName
   }).catch(e => {
     console.log(e)
   });
+}
+
+export function getRoomById(roomId) {
+ return fetch(`/matrix/rest/matrix/byRoomId?roomId=${roomId}`, {
+     method: 'GET',
+     credentials: 'include',
+   }).then(resp => {
+     if (!resp || !resp.ok) {
+       throw new Error('Get Room by Room Id : Response code indicates a server error or space not found', resp);
+     } else {
+       return resp.json();
+     }
+   });
 }
 
 export async function longPollingSync(matrixFilterId) {
@@ -575,7 +604,7 @@ export async function loadAllRoomMessages(roomId, loadAll) {
   while (true) {
     const response = await loadRoomMessages(roomId, loadFrom);
     const data = await response.json();
-    if (!data.chunk.length) {
+    if (!data.chunk?.length) {
       localStorage.setItem(`${roomId}-latest-messages-from`, from);
       localStorage.setItem(`${roomId}-latest-messages-to`, to);
       break;


### PR DESCRIPTION
The discussion rooms are sorted by :
1- latest room that received a new message is moved to the top
2- Creation date
3- If there is no message yet, and creation date is missing, then they are sorted with Natural sorting order
