### PR TITLE
feat: scroll instantly to the latest viewed message with load more - MEED-8453 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -130,7 +130,7 @@ export default {
       this.loading = true;
       this.room = e;
       this.$matrixService.loadRoomMessages(this.room.id).then(resp => {
-        if(!resp.chunk || !resp.chunk.length) {
+        if(!resp.chunk || !resp.chunk.length || resp.chunk.length < this.$chatConstants.MESSAGES_LOAD_LIMIT) {
           this.hasMoreMessages = false;
         }
         this.messages = resp.chunk.reverse();
@@ -195,12 +195,9 @@ export default {
           this.from = resp.start;
           this.to = resp.end;
         }).finally(() => {
-          this.$nextTick().then(() => {
-            document.getElementById(lastMessageId).scrollIntoView({
-              behavior: 'smooth'
-            });
+          document.getElementById(`message-content-${lastMessageId}`).scrollIntoView({
+            behavior: 'instant'
           });
-
           this.loadingNewMessages = false;
         });
       }, 1000);

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatMessage.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatMessage.vue
@@ -25,6 +25,7 @@
         </div>
         <div class="chat-message-content-body py-2 px-3 mt-0-5" :class="messageContentClass">
           <div
+            :id="`message-content-${message.event_id}`"
             class="chat-message-content-text"
             v-sanitized-html="formattedMessage" />
           <v-tooltip bottom>

--- a/webapp/src/main/webapp/vue-apps/matrix/js/Constants.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/Constants.js
@@ -26,5 +26,5 @@ export const chatConstants = {
 
   ENTER_CODE_KEY: 13,
 
-
+  MESSAGES_LOAD_LIMIT : 20,
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -10,7 +10,6 @@ const MATRIX_SYNC_TIMEOUT = 30000;
 const MATRIX_ACTION_MESSAGE_RECEIVED = 'matrix-message-received';
 const PUSH_APP_ID = "exo.matrix.app";
 const PUSH_APP_DISPLAY_NAME = 'Meeds application';
-const MESSAGES_LOAD_LIMIT = 20;
 
 
 export function checkAuthenticationTypes() {
@@ -591,7 +590,7 @@ export function getUserByMatrixId(userIdOnMatrix) {
 export async function loadRoomMessages(roomId, from, to) {
   const filter = {types:['m.room.message'],};
   const formData = new FormData();
-  formData.append('limit', MESSAGES_LOAD_LIMIT);
+  formData.append('limit', chatConstants.MESSAGES_LOAD_LIMIT);
   if(from) {
     formData.append('from', from);
   }


### PR DESCRIPTION
When scrolling to the top, the message list is updated and it renders the latest loaded message.
The fix avoids that and renders the last viewed messages and appends the new messages on the top.