### PR TITLE
fix: chat action in popover uses - MEED-7723 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/extension.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/extension.js
@@ -9,7 +9,7 @@ export function registerChatExtensions(chatTitle) {
     iconOnly: true,
     order: 10,
     enabled: (identity) => {
-      if(identity.userName) {
+      if(identity.userName || identity.username) {
         const userMatrixId = identity.properties?.some(property => property.propertyName === 'matrixId') && identity.properties?.find(property => property.propertyName === 'matrixId').value;
         return identity?.enabled && identity.username !== eXo.env.portal.userName
                && localStorage.getItem("matrix_user_id")
@@ -19,10 +19,11 @@ export function registerChatExtensions(chatTitle) {
       }
     },
     click: (profile) => {
-      if(profile.userName) {
+      const userName = profile.userName || profile.username;
+      if(userName) {
         const matrixProperty = profile.properties.filter(property => property.propertyName === 'matrixId');
         if(matrixProperty && matrixProperty.length) {
-          matrixService.openDMRoom(eXo.env.portal.userName, profile.userName, matrixServerName);
+          matrixService.openDMRoom(eXo.env.portal.userName, userName, matrixServerName);
         }
       } else {
         matrixService.openSpaceRoom(profile.id);


### PR DESCRIPTION
the user profile has sometimes the user name in property username or userName which causes issue if we use one of them without the other one. (Note there is an uppercase N in the property name)
The fix checks the value of both properties to use the correct one