### PR TITLE
feat: update message indicator when room is opened - MEED-8519 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -163,11 +163,13 @@ export default {
     scrollToEnd() {
       setTimeout( () => {
         if(this.messages) {
-          const lastMessageElement = document.getElementById(`chat-message-${this.messages.length - 1}`);
+          const lastMessageIndex = this.messages.length - 1;
+          const lastMessageElement = document.getElementById(`chat-message-${lastMessageIndex}`);
           if(lastMessageElement) {
-            document.getElementById(`chat-message-${this.messages.length - 1}`).scrollIntoView({
+            document.getElementById(`chat-message-${lastMessageIndex}`).scrollIntoView({
               behavior: 'smooth'
             });
+            this.$matrixService.markRoomAsFullyRead(this.room.id, this.messages[lastMessageIndex]?.event_id);
           }
         }
       }, 100);

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -108,6 +108,7 @@
       document.addEventListener('matrix-message-received', event => this.messageReceived(event));
       document.addEventListener('matrix-user-status-updated', event => this.userStatusUpdated(event));
       document.addEventListener(this.$chatConstants.ACTION_OPEN_CHAT_ROOM, event => this.openRoom(event.detail));
+      document.addEventListener('matrix-room-mark-full-read', event => this.updateUnreadMessages(event));
     },
     beforeDestroy() {
       this.$root.$off('chat-event-total-unread-updated',e => this.totalUnreadMessages = e);
@@ -115,6 +116,7 @@
       document.removeEventListener('matrix-message-received', event => this.messageReceived(event));
       document.removeEventListener('matrix-user-status-updated', event => this.userStatusUpdated(event));
       document.removeEventListener(this.$chatConstants.ACTION_OPEN_CHAT_ROOM, event => this.openRoom(event.detail));
+      document.removeEventListener('matrix-room-mark-full-read', event => this.updateUnreadMessages(event));
     },
     watch: {
       open() {
@@ -134,12 +136,14 @@
         this.open = true;
       },
       messageReceived(event) {
-        this.totalUnreadMessages ++;
         const updatedRoomIndex = this.rooms.findIndex(room => room.id === event.detail.roomId);
         const updatedRoom = this.rooms[updatedRoomIndex];
         if(updatedRoom) {
           updatedRoom.lastMessage = updatedRoom.lastMessage ? updatedRoom.lastMessage : {};
-          updatedRoom.unreadMessages += 1;
+          if(matrixUserId !== event.detail.sender) {
+            this.totalUnreadMessages ++;
+            updatedRoom.unreadMessages += 1;
+          }
           this.rooms.splice(updatedRoomIndex, 1);
           this.rooms.unshift(updatedRoom);
           updatedRoom.updated = event.detail.origin_server_ts;
@@ -153,6 +157,14 @@
                                                 senderIdentity.profile.fullname).replace('{1}', event.detail.message);
             });
           }
+        }
+      },
+      updateUnreadMessages(event) {
+        const updatedRoomIndex = this.rooms.findIndex(room => room.id === event.detail.roomId);
+        const updatedRoom = this.rooms[updatedRoomIndex];
+        if(updatedRoom) {
+          this.totalUnreadMessages -= updatedRoom.unreadMessages;
+          updatedRoom.unreadMessages = 0;
         }
       },
       userStatusUpdated(event) {

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -235,6 +235,26 @@ export function processEvents(response) {
           }
         }
       });
+      const ephemeralEvents = response.rooms.join[roomId].ephemeral?.events;
+      ephemeralEvents.forEach(e => {
+        //Users are typing in the room
+        if(e.type === 'm.typing') {
+          if(e.content.user_ids?.length) {
+            console.log(`Users ${e.content.user_ids} are typing on room ${roomId}`);
+            //document.dispatchEvent(new CustomEvent('matrix-room-user-typing-received', { detail: {roomId: roomId, usersTyping: e.content.user_ids}}));
+          }
+        }
+        //User sent a read receipt of a room
+        if(e.type === 'm.receipt') {
+          if(e.content) {
+            for (const eventId in e.content) {
+              if(e.content[eventId]["m.read"][matrixUserId]?.thread_id) {
+                document.dispatchEvent(new CustomEvent('matrix-room-mark-full-read', { detail: {roomId: roomId}}));
+              }
+            }
+          }
+        }
+      });
     }
   }
   if(response?.presence?.events) {
@@ -694,6 +714,33 @@ export function sendMessage(message, roomId) {
       throw new Error('Response code indicates a server error', resp);
     } else {
       localStorage.setItem('matrix_transaction_index', index ++);
+      return true;
+    }
+  });
+}
+
+export function markRoomAsFullyRead(roomId, eventId) {
+  if(!roomId) {
+    console.warn('No roomId provided, Mark as read call will be canceled')
+    return;
+  }
+  if(!eventId) {
+    console.warn('No event Id provided, Mark as read call will be canceled')
+    return;
+  }
+  const payload = {
+                    "thread_id": "main"
+                  };
+  return fetch(`/_matrix/client/v3/rooms/${roomId}/receipt/m.read/${eventId}`, {
+    method: 'POST',
+    headers: {
+      'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
+    },
+    body: JSON.stringify(payload)
+  }).then(resp => {
+    if (!resp?.ok) {
+      throw new Error('Mark room as fully read : Response code indicates a server error', resp);
+    } else {
       return true;
     }
   });


### PR DESCRIPTION
When a room is opened in the chat drawer, the unread message indicator wasn't updated or reset to 0
The fix resets the number of unread messages in the room and updates the number of total unread messages.