### PR TITLE
fix: disable refresh on swipe down and load more messages - MEED-8589 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/css/matrix.less
+++ b/webapp/src/main/webapp/css/matrix.less
@@ -207,6 +207,7 @@
   #chatMessagesContainer {
     height: 100%;
     overflow: auto;
+    overscroll-behavior: none;
   }
   .drawerFooter {
     background-color: @primaryBackground;

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -40,7 +40,10 @@
       </div>
     </template>
     <template slot="content">
-      <div id="chatMessagesContainer">
+      <div id="chatMessagesContainer"
+        v-touch="{
+          down: () => loadMoreMessages()
+        }">
         <div
           v-if="loadingNewMessages"
           class="application-background-color application-border application-border-radius flex d-flex flex-column">


### PR DESCRIPTION
On Mobile when scrolling down, the page is refreshed which prevents loading the room history.
The fix disables swipe to refresh action fro the Chat discussion drawer and fires the loadMessages action when the top is reached