### PR TITLE
fix: open immediately discussion on last message - MEED-8546 - Meeds-io/MIPs#163

### DIFF
--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -338,7 +338,7 @@ public class MatrixRest implements ResourceContainer {
                                                 String roomId) {
     String userName = request.getRemoteUser();
     Room room = matrixService.getById(roomId);
-    if (!matrixService.canAccess(room, userName)) {
+    if (room == null || !matrixService.canAccess(room, userName)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN);
     }
     RoomEntity roomEntity = buildRoomEntityFromRoom(room, userName);

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -55,6 +55,7 @@
         </div>
         <div
           id="roomChatMessages"
+          v-show="messages && !loading"
           class="d-flex flex-column"
           @wheel="loadMoreMessages"
           @scroll="loadMoreMessages">
@@ -143,7 +144,6 @@ export default {
 
   created() {
     document.addEventListener('matrix-message-received', event => this.messageReceived(event));
-    document.addEventListener(this.$chatConstants.ACTION_OPEN_CHAT_ROOM,e => this.openDiscussion(e.detail));
     this.$root.$on('open-chat-discussion',e => this.openDiscussion(e));
     this.$root.$on('room-discussion-opened', () => this.initRoomActionComponents());
   },
@@ -157,7 +157,6 @@ export default {
   },
   beforeDestroy() {
     document.removeEventListener('matrix-message-received', event => this.messageReceived(event));
-    document.removeEventListener(this.$chatConstants.ACTION_OPEN_CHAT_ROOM,e => this.openDiscussion(e.detail));
     this.$root.$off('open-chat-discussion',e => this.openDiscussion(e));
     this.$root.$on('room-discussion-opened', () => this.initRoomActionComponents());
   },
@@ -165,20 +164,19 @@ export default {
     openDiscussion(e) {
       this.loading = true;
       this.room = e;
+      this.$refs.ChatDiscussionDrawer?.open();
       this.$matrixService.loadRoomMessages(this.room.id).then(resp => {
         if(!resp.chunk || !resp.chunk.length || resp.chunk.length < this.$chatConstants.MESSAGES_LOAD_LIMIT) {
           this.hasMoreMessages = false;
         }
-        this.messages = resp.chunk.reverse();
         this.from = resp.start;
         this.to = resp.end;
-        this.$refs.ChatDiscussionDrawer?.open();
+        this.messages = resp.chunk.reverse();
         this.$nextTick().then(() => {
           this.scrollToEnd();
+          this.loading = false;
           this.$root.$emit('room-discussion-opened');
         });
-      }).finally(() => {
-        this.loading = false;
       });
     },
     close(){
@@ -188,6 +186,7 @@ export default {
       this.$refs.messageComposerArea.innerHTML = '';
       this.$refs.ChatDiscussionDrawer?.close();
       this.initializedActions = [];
+      this.roomActionComponents = [];
     },
     messageReceived(event) {
       if(this.room?.id === event.detail.roomId && this.$refs.ChatDiscussionDrawer?.drawer) {
@@ -199,18 +198,16 @@ export default {
       }
     },
     scrollToEnd() {
-      setTimeout( () => {
-        if(this.messages) {
-          const lastMessageIndex = this.messages.length - 1;
-          const lastMessageElement = document.getElementById(`chat-message-${lastMessageIndex}`);
-          if(lastMessageElement) {
-            document.getElementById(`chat-message-${lastMessageIndex}`).scrollIntoView({
-              behavior: 'smooth'
-            });
-            this.$matrixService.markRoomAsFullyRead(this.room.id, this.messages[lastMessageIndex]?.event_id);
-          }
+      if(this.messages) {
+        const lastMessageIndex = this.messages.length - 1;
+        const lastMessageElement = document.getElementById(`chat-message-${lastMessageIndex}`);
+        if(lastMessageElement) {
+          document.getElementById(`chat-message-${lastMessageIndex}`).scrollIntoView({
+            behavior: 'instant'
+          });
+          this.$matrixService.markRoomAsFullyRead(this.room.id, this.messages[lastMessageIndex]?.event_id);
         }
-      }, 100);
+      }
     },
     loadMoreMessages() {
       const messagesDOMEl = document.getElementById('chatMessagesContainer');


### PR DESCRIPTION
When opening a discussion, the messages are displayed then a scroll is done to display the last message
The fix will display the loading action until messages are loaded and the scroll is done to the last message instantly
