### PR TITLE
fix: update UI of day timestamp - MEED-8514 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatMessage.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatMessage.vue
@@ -32,8 +32,8 @@
             </div>
           </a>
         </div>
-        <div class="chat-message-content-body py-2 px-3 mt-0-5"
-          :class="messageContentClass">
+        <div class="chat-message-content-body py-2 px-3"
+          :class="[messageContentClass, {'mt--4':displaySender}, {'mt-0-5':!displaySender}]">
           <div
             :id="`message-content-${message.event_id}`"
             class="chat-message-content-text"
@@ -114,10 +114,12 @@
       },
       formattedDate() {
         let today = new Date();
-        today.setHours(0,0,0,0);
+        const todayTime = today.setHours(0,0,0,0);
+        const messageDate = new Date(this.message.origin_server_ts);
+        const messageDateTime = messageDate.setHours(0,0,0,0);
         if(this.$timeUtils.isSameDay(today, this.message.origin_server_ts)) {
           return this.$t('matrix.chat.time.today');
-        } else if(this.$timeUtils.differenceInDays(today, this.message.origin_server_ts) === -1) {
+        } else if(this.$timeUtils.differenceInDays(todayTime, messageDateTime) === 1) { // one day before
           return this.$t('matrix.chat.time.yesterday');
         } else {
           return this.$matrixService.formatDateString(this.message.origin_server_ts);

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -692,33 +692,26 @@ export function formatDateString(dateToFormat) {
   resetDateToFormat.setHours(0,0,0,0);
   let options = {};
   const localeOfUser = eXo.env.portal.language.replace('_', '-');
-  if (new Date(today).getFullYear() !== new Date(dateToFormat).getFullYear()) {// Not in the same year
+  if (new Date(today).getFullYear() !== new Date(resetDateToFormat).getFullYear()) {// Not in the same year
     options = {
       year: "numeric",
       month: "short",
       day: "numeric"
     };
-    return dateToFormat.toLocaleDateString(localeOfUser, options);
-  } else if (new Date(today).getFullYear() === new Date(dateToFormat).getFullYear()) {// In the same year
+    return new Date(resetDateToFormat).toLocaleDateString(localeOfUser, options);
+  } else if (new Date(today).getFullYear() === new Date(resetDateToFormat).getFullYear()) {// In the same year
     options = {
       weekday: "short",
       style: "short",
       month: "short",
       day: "numeric",
     };
-    return dateToFormat.toLocaleDateString(localeOfUser, options);
-  } else if (differenceInDays(today - dateToFormat) < 7){ // In the same week
+    return new Date(resetDateToFormat).toLocaleDateString(localeOfUser, options);
+  } else if (differenceInDays(today - resetDateToFormat) < 7){ // In the same week
     options = {
       weekday: "long"
     };
-    return dateToFormat.toLocaleDateString(localeOfUser, options);
-  } else { // otherwise
-    options = {
-      year: "numeric",
-      month: "short",
-      day: "numeric"
-    };
-    return dateToFormat.toLocaleDateString(localeOfUser, options);
+    return new Date(resetDateToFormat).toLocaleDateString(localeOfUser, options);
   }
 }
 


### PR DESCRIPTION
Update the UI of the day in the discussion drawer to display :
 - today, if the message is from the same day
 - tomorrow : if the message is from yesterday
 -  day of the week : if the message is from a previous day less than 7 days
 - Date without year, if the message is from the same year
 - Date with year otherwise