### PR TITLE
fix: set default color for background - MEED-8685 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/css/matrix.less
+++ b/webapp/src/main/webapp/css/matrix.less
@@ -195,7 +195,7 @@
     }
 
     .chat-message-from-self {
-      background-color: @primaryColor;
+      background-color: #476A9C;
       color: #FFFFFF;
       border-radius: 16px;
       margin-left: auto;


### PR DESCRIPTION
Set the default background color for messages sent by the current user to #476A9C