### PR TITLE
feat: increase composer height to avoid scroll display - MEED-8679 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -223,7 +223,7 @@ export default {
       const scrollTop = messagesDOMEl.scrollTop;
       if (scrollTop < this.lastScrollTop) {
         const composerDOMEl = document.getElementById('messageComposerArea');
-        composerDOMEl.style = 'height: 40px'; // resize composer to original size == 1 line
+        composerDOMEl.style = 'height: 54px'; // resize composer to original size == 1 line
       }
       this.lastScrollTop = scrollTop >= 0 && scrollTop || 0;
       if(this.loadingNewMessages || !this.hasMoreMessages || messagesDOMEl.scrollTop > 0) {
@@ -255,7 +255,7 @@ export default {
       }
       const composerElement = e.target;
       composerElement.style.height = "auto";
-      composerElement.style.height = composerElement.scrollHeight + "px";
+      composerElement.style.height = Number(composerElement.scrollHeight + 4) + "px";
       this.disableSendMessage = composerElement.innerText?.trim() === '';
     },
     sendMessageWithEnter(event) {


### PR DESCRIPTION
On some browser, when mentioning a user, there is a scroll bar displayed on the message composer area due to the exact height set to that element, which activates scrolling when a user is mentioned.
we simply increased the height of the element by 4px