### PR TITLE
fix: avoid duplicating drawer for chat discussions - MEED-8686 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
@@ -1,10 +1,11 @@
 <template>
   <exo-drawer
     ref="meedsChatDrawer"
+    id="meedsChatDrawer"
     :loading="loading > 0"
     class="meeds-chat-drawer"
     right
-    @closed="$emit('closed')">
+    @closed="close">
     <template slot="title">
       <div class="d-flex">
         <div
@@ -81,9 +82,12 @@ export default {
   },
   methods: {
     open() {
-      this.$refs.meedsChatDrawer.open();
+    if(!this.$refs.meedsChatDrawer.drawer) {
+        this.$refs.meedsChatDrawer.open();
+      }
     },
     close() {
+      this.$refs.ChatDiscussionDrawer.close();
       this.$refs.meedsChatDrawer.close();
     },
     incrementLoading() {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -146,18 +146,10 @@ export default {
       return `( ${this.$t('matrix.chat.user.external')} )`;
     },
   },
-
   created() {
     document.addEventListener('matrix-message-received', event => this.messageReceived(event));
     this.$root.$on('open-chat-discussion',e => this.openDiscussion(e));
     this.$root.$on('room-discussion-opened', () => this.initRoomActionComponents());
-  },
-
-  mounted() {
-
-  },
-  updated() {
-
   },
   watch:{
     room() {
@@ -173,7 +165,9 @@ export default {
     openDiscussion(e) {
       this.loading = true;
       this.room = e;
-      this.$refs.ChatDiscussionDrawer?.open();
+      if(!this.$refs.ChatDiscussionDrawer?.drawer) {
+        this.$refs.ChatDiscussionDrawer?.open();
+      }
       this.$matrixService.loadRoomMessages(this.room.id).then(resp => {
         if(!resp.chunk || !resp.chunk.length || resp.chunk.length < this.$chatConstants.MESSAGES_LOAD_LIMIT) {
           this.hasMoreMessages = false;
@@ -196,6 +190,7 @@ export default {
       this.$refs.ChatDiscussionDrawer?.close();
       this.initializedActions = [];
       this.roomActionComponents = [];
+      this.lastScrollTop = 0;
     },
     messageReceived(event) {
       if(this.room?.id === event.detail.roomId && this.$refs.ChatDiscussionDrawer?.drawer) {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/chatButton.vue
@@ -134,6 +134,7 @@
       openDrawer() {
         this.$root.initialized = false;
         this.open = true;
+        this.$refs.meedsChatDrawer?.open();
       },
       messageReceived(event) {
         const updatedRoomIndex = this.rooms.findIndex(room => room.id === event.detail.roomId);


### PR DESCRIPTION


Make sure to close all drawers when closing the chat to avoid duplication. This caused some issues like infinite scrolling to top even when the top is not reached.
