### PR TITLE
fix: replace Matrix unallowed chars with hyphen character - MEED-9102 - Meeds-io/MIPs#163

### DIFF
--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -217,6 +217,7 @@ public class MatrixService {
    */
   public String getJWTSessionToken(String userNameOnMatrix) {
     Date expirtaionDate = Date.from(Instant.now().plusSeconds(7 * 24 * 60 * 60L)); // adds one week to the current instant
+    userNameOnMatrix = userNameOnMatrix.replaceAll("[^a-zA-Z=_\\-\\.\\/+]+", "-");
     return Jwts.builder()
                .setSubject(userNameOnMatrix)
                .signWith(Keys.hmacShaKeyFor(PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes()))


### PR DESCRIPTION
The fix replaces unauthorized characters in Matrix user IDs with hyphen to avoid error
