### PR TITLE
fix: escape correctly unauthorized characters before creating a 1:1 room - MEED-9161 - Meeds-io/MIPs#163

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatQuickCreateDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatQuickCreateDiscussionDrawer.vue
@@ -105,7 +105,13 @@ export default {
       const remoteId = this.participant.remoteId;
       if(remoteId) {
         this.close();
-        this.$matrixService.openDMRoom(eXo.env.portal.userName, remoteId, matrixServerName);
+        this.$identityService.getIdentityByProviderIdAndRemoteId('organization', remoteId, 'settings').then(identity => {
+          const matrixProperty = identity.profile.dataEntity.properties.filter(property => property.propertyName === 'matrixId');
+          if(matrixProperty && matrixProperty.length > 0) {
+            const invitedUserMatrixId = matrixProperty[0].value;
+            this.$matrixService.openDMRoom(eXo.env.portal.userName, remoteId, matrixServerName, matrixUserId, invitedUserMatrixId);
+          }
+        });
       }
     }
   }

--- a/webapp/src/main/webapp/vue-apps/matrix/components/PopoverChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/PopoverChatButton.vue
@@ -47,7 +47,7 @@ export default {
           if(matrixIdProperty) {
             this.contactMatrixId = matrixIdProperty.value;
             if(this.contactMatrixId) {
-              this.$matrixService.openDMRoom(eXo.env.portal.userName, data.userName, matrixServerName);
+              this.$matrixService.openDMRoom(eXo.env.portal.userName, data.userName, matrixServerName, matrixUserId, this.contactMatrixId);
             }
           }
         });

--- a/webapp/src/main/webapp/vue-apps/matrix/extension.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/extension.js
@@ -24,8 +24,9 @@ export function registerChatExtensions(chatTitle) {
       const userName = profile.userName || profile.username;
       if(userName) {
         const matrixProperty = profile.properties.filter(property => property.propertyName === 'matrixId');
-        if(matrixProperty && matrixProperty.length) {
-          matrixService.openDMRoom(eXo.env.portal.userName, userName, matrixServerName);
+        if(matrixProperty && matrixProperty.length > 0) {
+          const invitedUserMatrixId = matrixProperty[0].value;
+          matrixService.openDMRoom(eXo.env.portal.userName, userName, matrixServerName, matrixUserId, invitedUserMatrixId);
         }
       } else {
         matrixService.openSpaceRoom(profile.id);

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -121,7 +121,7 @@ export function loadRoom(roomId) {
   });
 }
 
-export function createMatrixDMRoom(matrixIDUserOne, matrixIdUserTwo, serverName) {
+export function createMatrixDMRoom(matrixIdUserTwo, serverName) {
   const payLoad = {
                      "preset": "trusted_private_chat",
                      "visibility": "private",
@@ -437,13 +437,13 @@ export function getSpaceRoom(spaceId) {
   });
 }
 
-export function getDMRoom(firstParticipant, secondParticipant, serverName) {
+export function getDMRoom(firstParticipant, secondParticipant, serverName, firstUserMatrixId, secondUserMatrixId) {
   return fetch(`/matrix/rest/matrix/dmRoom?firstParticipant=${firstParticipant}&secondParticipant=${secondParticipant}`, {
     method: 'GET',
   }).then(resp => {
     if (!resp || !resp.ok) {
       if(resp.status === 404) {
-        return createMatrixDMRoom(firstParticipant, secondParticipant, serverName).then(data => {
+        return createMatrixDMRoom(secondUserMatrixId || secondParticipant, serverName).then(data => {
           const payload = {
                             "roomId": data.room_id,
                             "firstParticipant": firstParticipant,
@@ -479,8 +479,8 @@ export function getDMRoom(firstParticipant, secondParticipant, serverName) {
   });
 }
 
-export function openDMRoom(firstParticipant, secondParticipant, matrixServerName) {
-  getDMRoom(firstParticipant, secondParticipant, matrixServerName).then(data => {
+export function openDMRoom(firstParticipant, secondParticipant, matrixServerName, firstUserMatrixId, secondUserMatrixId) {
+  getDMRoom(firstParticipant, secondParticipant, matrixServerName, firstUserMatrixId, secondUserMatrixId).then(data => {
     document.dispatchEvent(new CustomEvent(chatConstants.ACTION_OPEN_CHAT_ROOM, { detail : data }));
   }).catch(e => {
     console.log(e)


### PR DESCRIPTION
Before creating a 1:1 room in Matrix, all unauthorized characters should be removed from the user name. 