### PR TITLE
fix: load rooms from backend to avoid latency from Matrix server - MEED-9262 - Meeds-io/MIPs#163

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,7 +34,7 @@
   </build>
 
   <properties>
-    <exo.test.coverage.ratio>0.34</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.4</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/io/meeds/chat/dao/MatrixRoomDAO.java
+++ b/services/src/main/java/io/meeds/chat/dao/MatrixRoomDAO.java
@@ -45,4 +45,6 @@ public interface MatrixRoomDAO extends JpaRepository<RoomEntity, Long> {
   public RoomEntity findByRoomIdStartsWith(String roomId);
 
   public List<RoomEntity> findBySpaceIdIsNotNull();
+
+  public List<RoomEntity> findBySpaceIdIn(List<String> spaceIds);
 }

--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.service.MatrixService;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
@@ -41,7 +40,6 @@ import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.api.notification.service.storage.NotificationService;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.PropertyManager;
-import org.exoplatform.portal.localization.LocaleContextInfoUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
@@ -49,7 +47,6 @@ import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.rest.api.RestUtils;
@@ -64,7 +61,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.io.IOException;
 import java.util.*;
 
 import static io.meeds.chat.service.utils.MatrixConstants.*;
@@ -102,9 +98,10 @@ public class MatrixRest implements ResourceContainer {
   @ApiResponses(value = { @ApiResponse(responseCode = "2rest00", description = "Request fulfilled"),
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
-  public RoomEntity getMatrixRoomBySpaceId(@Parameter(description = "The space Id")
-  @RequestParam(name = "spaceId")
-  String spaceId) {
+  public RoomEntity getMatrixRoomBySpaceId(HttpServletRequest request,
+                                           @Parameter(description = "The space Id")
+                                           @RequestParam(name = "spaceId")
+                                           String spaceId) {
     if (StringUtils.isBlank(spaceId)) {
       LOG.error("Could not get the URL for the space, missing space ID");
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "the space Id parameter is required!");
@@ -114,7 +111,7 @@ public class MatrixRest implements ResourceContainer {
       LOG.error("Could not find a space with id {}", spaceId);
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Can not find a space with Id = " + spaceId);
     }
-    String userName = ConversationState.getCurrent().getIdentity().getUserId();
+    String userName = request.getRemoteUser();
     if (!spaceService.isMember(space, userName) && !spaceService.isManager(space, userName)
         && !spaceService.isSuperManager(userName)) {
       LOG.error("User is not allowed to get the team associated with the space {}", space.getDisplayName());
@@ -224,40 +221,42 @@ public class MatrixRest implements ResourceContainer {
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public boolean linkSpaceToRoom(@RequestParam("spaceGroupId")
-  String spaceGroupId, @RequestParam(name = "roomId")
-  String roomId, @RequestParam(name = "create", required = false)
-  Boolean create) {
-    try {
-      if (StringUtils.isBlank(spaceGroupId)) {
-        LOG.error("Could not connect the space to a team, space name is missing");
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "space group Id is required");
-      }
-
-      Space space = spaceService.getSpaceByGroupId("/spaces/" + spaceGroupId);
-
-      if (space == null) {
-        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "space with group Id " + spaceGroupId + "was not found");
-      }
-
-      Room room = matrixService.getRoomBySpace(space);
-      if (StringUtils.isNotBlank(room.getRoomId())) {
-        throw new ResponseStatusException(HttpStatus.CONFLICT,
-                                          "space with group Id " + spaceGroupId + "has already a room with ID "
-                                              + room.getRoomId());
-      }
-
-      if (StringUtils.isBlank(roomId) && create) {
-        roomId = matrixService.createRoomForSpaceOnMatrix(space);
-      }
-
-      matrixService.linkSpaceToMatrixRoom(space, roomId);
-      return true;
-    } catch (Exception e) {
-      LOG.error("Could not link space {} to Matrix room {}", spaceGroupId, roomId, e);
-      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                                        "Could not link space " + spaceGroupId + " to Matrix room " + roomId + " : "
-                                            + e.getMessage());
+                                 String spaceGroupId,
+                                 @RequestParam(name = "roomId")
+                                 String roomId,
+                                 @RequestParam(name = "create", required = false)
+                                 Boolean create) {
+    if (StringUtils.isBlank(spaceGroupId)) {
+      LOG.error("Could not connect the space to a team, space name is missing");
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "space group Id is required");
     }
+
+    Space space = spaceService.getSpaceByGroupId("/spaces/" + spaceGroupId);
+
+    if (space == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "space with group Id " + spaceGroupId + " was not found");
+    }
+
+    Room room = matrixService.getRoomBySpace(space);
+    if (room != null && StringUtils.isNotBlank(room.getRoomId())) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT,
+                                        "space with group Id " + spaceGroupId + "has already a room with ID "
+                                            + room.getRoomId());
+    }
+
+    if (StringUtils.isBlank(roomId) && create) {
+      try {
+        roomId = matrixService.createRoomForSpaceOnMatrix(space);
+      } catch (Exception e) {
+        LOG.error("Could not link space {} to Matrix room {}", spaceGroupId, roomId, e);
+        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                "Could not link space " + spaceGroupId + " to Matrix room " + roomId + " : "
+                        + e.getMessage());
+      }
+    }
+
+    matrixService.linkSpaceToMatrixRoom(space, roomId);
+    return true;
   }
 
   @GetMapping("dmRooms")
@@ -267,8 +266,8 @@ public class MatrixRest implements ResourceContainer {
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public Map<String, String[]> getUserDirectMessagingRooms(@Parameter(description = "The user")
-  @RequestParam(name = "user")
-  String user) {
+                                                           @RequestParam(name = "user")
+                                                           String user) {
 
     Map<String, String[]> userDMRooms = new HashMap<>();
     List<Room> rooms = matrixService.getMatrixDMRoomsOfUser(user);
@@ -333,6 +332,9 @@ public class MatrixRest implements ResourceContainer {
                                                 @Parameter(description = "The room Id")
                                                 @RequestParam(name = "roomId")
                                                 String roomId) {
+    if(StringUtils.isBlank(roomId)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "roomId parameter is required");
+    }
     String userName = request.getRemoteUser();
     Room room = matrixService.getById(roomId);
     if (room == null || !matrixService.canAccess(room, userName)) {
@@ -466,7 +468,12 @@ public class MatrixRest implements ResourceContainer {
 
   private RoomEntity buildRoomEntityFromRoom(Room room, String currentUserName) {
     RoomEntity roomEntity = new RoomEntity();
-    roomEntity.setId(room.getRoomId());
+    String roomId = room.getRoomId();
+    String serverName = PropertyManager.getProperty(MATRIX_SERVER_NAME);
+    if(!roomId.contains(serverName)) {
+      roomId = roomId + ":" + serverName;
+    }
+    roomEntity.setId(roomId);
     if (StringUtils.isNotBlank(room.getSpaceId())) {
       roomEntity.setSpaceId(room.getSpaceId());
       roomEntity.setDirectChat(false);
@@ -499,9 +506,25 @@ public class MatrixRest implements ResourceContainer {
       throw new IllegalArgumentException("The username of the current user is mandatory");
     }
 
+    List<String> spaceIds = spaceService.getMemberSpacesIds(currentUserName, 0, -1);
+
     for (RoomEntity room : roomList.getRooms()) {
       updateRoomEntity(room, currentUserName);
+      //check missing rooms
+      if(!room.isDirectChat()) {
+        spaceIds.remove(room.getSpaceId());
+      }
     }
+    if(!spaceIds.isEmpty()) {
+      for(String spaceId : spaceIds) {
+        Room missingRoom = matrixService.getRoomBySpaceId(spaceId);
+        if(missingRoom != null) {
+          RoomEntity missingRoomEntity = buildRoomEntityFromRoom(missingRoom, currentUserName);
+          roomList.getRooms().addFirst(missingRoomEntity);
+        }
+      }
+    }
+
     return roomList;
   }
 

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -22,6 +22,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import io.meeds.chat.model.Room;
+import io.meeds.chat.rest.model.RoomList;
 import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.storage.MatrixRoomStorage;
 import jakarta.annotation.PostConstruct;
@@ -151,11 +152,20 @@ public class MatrixService {
   /**
    * Returns the ID of the room linked to a space
    * 
-   * @param space
+   * @param space the space
    * @return the roomId linked to the space
    */
   public Room getRoomBySpace(Space space) {
-    return matrixRoomStorage.getMatrixRoomBySpaceId(space.getId());
+    return getRoomBySpaceId(space.getId());
+  }
+  /**
+   * Returns the ID of the room linked to a space
+   *
+   * @param spaceId the space Id
+   * @return the roomId linked to the space
+   */
+  public Room getRoomBySpaceId(String spaceId) {
+    return matrixRoomStorage.getMatrixRoomBySpaceId(spaceId);
   }
 
   /**
@@ -511,5 +521,14 @@ public class MatrixService {
       Space space = spaceService.getSpaceById(room.getSpaceId());
       return spaceService.canViewSpace(space, userName);
     }
+  }
+
+  /**
+   * Load the list of space rooms
+   * @param spaceIds : list of space IDs
+   * @return List of Rooms
+   */
+  public List<Room> getSpaceRoomsBySpaceIds(List<String> spaceIds) {
+    return matrixRoomStorage.getSpaceRoomsBySpaceIds(spaceIds);
   }
 }

--- a/services/src/main/java/io/meeds/chat/storage/MatrixRoomStorage.java
+++ b/services/src/main/java/io/meeds/chat/storage/MatrixRoomStorage.java
@@ -154,4 +154,13 @@ public class MatrixRoomStorage {
   public List<Room> getSpaceRooms() {
     return toRoomList(matrixRoomDAO.findBySpaceIdIsNotNull());
   }
+
+  /**
+   * Load the list of space rooms
+   * @param spaceIds : list of space IDs
+   * @return List of Rooms
+   */
+  public List<Room> getSpaceRoomsBySpaceIds(List<String> spaceIds) {
+    return toRoomList(matrixRoomDAO.findBySpaceIdIn(spaceIds));
+  }
 }

--- a/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
+++ b/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
@@ -14,6 +14,7 @@ import io.meeds.spring.web.security.PortalAuthenticationManager;
 import io.meeds.spring.web.security.WebSecurityConfiguration;
 import jakarta.servlet.Filter;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.service.storage.NotificationService;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.services.resources.ResourceBundleService;
@@ -50,6 +51,9 @@ import org.springframework.web.context.WebApplicationContext;
 import java.util.*;
 
 import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_SERVER_NAME;
+import static io.meeds.chat.service.utils.MatrixConstants.USER_MATRIX_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -130,25 +134,58 @@ class MatrixRestTest {
 
   @Test
   public void testProcessRooms() throws Exception {
-    RoomEntity roomEntity = createRoomEntity(0);
-    Room room = new Room();
-    room.setRoomId("!testRoom0:matrix.meeds.tn");
-    room.setSpaceId("spaceId");
+    RoomEntity roomEntity1 = createRoomEntity(1);
+    roomEntity1.setSpaceId("1");
+    RoomEntity roomEntity2 = createRoomEntity(2);
+    roomEntity2.setSpaceId("2");
+    RoomEntity roomEntity3 = createRoomEntity(3);
+    roomEntity3.setSpaceId("3");
+    Room room1 = new Room();
+    room1.setRoomId("!testRoom1:matrix.meeds.tn");
+    room1.setSpaceId("1");
+    Room room2 = new Room();
+    room2.setRoomId("!testRoom2:matrix.meeds.tn");
+    room2.setSpaceId("2");
+    Room room3 = new Room();
+    room3.setRoomId("!testRoom3:matrix.meeds.tn");
+    room3.setSpaceId("3");
     RoomList roomsList = new RoomList();
     roomsList.setTotalUnreadMessages(5);
-    roomsList.setRooms(Collections.singletonList(roomEntity));
-    when(matrixService.getById("!testRoom0")).thenReturn(room);
-    Space space = new Space();
-    space.setDisplayName("Space of Heroes");
-    space.setAvatarUrl("/Url/Of/Avatar.png");
-    space.setMembers(new String[]{"user1", "user2"});
-    when(spaceService.getSpaceById("spaceId")).thenReturn(space);
+    roomsList.setRooms(List.of(roomEntity1, roomEntity2));
+    when(matrixService.getById("!testRoom1")).thenReturn(room1);
+    when(matrixService.getById("!testRoom2")).thenReturn(room2);
+    when(matrixService.getById("!testRoom3")).thenReturn(room3);
+    Space space1 = new Space();
+    space1.setDisplayName("Space of Heroes");
+    space1.setAvatarUrl("/Url/Of/Avatar.png");
+    space1.setMembers(new String[]{"user1", "user2"});
+    when(spaceService.getSpaceById("1")).thenReturn(space1);
+    Space space2 = new Space();
+    space2.setDisplayName("Space of Heroes");
+    space2.setAvatarUrl("/Url/Of/Avatar.png");
+    space2.setMembers(new String[]{"user1", "user2"});
+    when(spaceService.getSpaceById("2")).thenReturn(space2);
+    Space space3 = new Space();
+    space3.setDisplayName("Space of Heroes");
+    space3.setAvatarUrl("/Url/Of/Avatar.png");
+    space3.setMembers(new String[]{"user1", "user2"});
+    when(spaceService.getSpaceById("3")).thenReturn(space3);
+    when(matrixService.getRoomBySpaceId("3")).thenReturn(room3);
+    when(spaceService.getMemberSpacesIds(SIMPLE_USER, 0, -1)).thenReturn(new ArrayList<>(List.of(new String [] {"1", "2", "3"})));
     ResultActions response = mockMvc.perform(post(REST_PATH + "/processRooms").with(simpleUser())
                                                                               .contentType(MediaType.APPLICATION_JSON)
                                                                               .content(asJsonString(roomsList)));
     response.andExpect(status().isOk());
+    response.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    // we should have roomEntity3 inside the response RoomList
+    RoomList expectedRoomList = fromJsonString(response.andReturn().getResponse().getContentAsString(), RoomList.class);
+    assertNotNull(expectedRoomList);
+    assertNotNull(expectedRoomList.getRooms());
+    assertEquals(3, expectedRoomList.getRooms().size());
+    assertEquals(5, expectedRoomList.getTotalUnreadMessages());
 
     //
+    Room room = new Room();
     room.setSpaceId(null);
     room.setFirstParticipant("root");
     room.setSecondParticipant("user");
@@ -275,5 +312,120 @@ class MatrixRestTest {
   void syncUsersAndSpaces() throws Exception {
     ResultActions response = mockMvc.perform(get(REST_PATH + "/sync").with(adminUser()).contentType(MediaType.APPLICATION_JSON));
     response.andExpect(status().isOk());
+  }
+
+  @Test
+  void getMatrixRoomBySpaceId() throws Exception {
+    ResultActions response = mockMvc.perform(get(REST_PATH).with(adminUser())
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isBadRequest());
+
+    response = mockMvc.perform(get(REST_PATH).with(simpleUser())
+            .param("spaceId", "1")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isNotFound());
+
+    Space space = new Space();
+    space.setAvatarUrl("/avatar/of/the/space");
+    space.setDisplayName("Test space");
+    when(spaceService.getSpaceById("1")).thenReturn(space);
+    when(spaceService.isMember(space, SIMPLE_USER)).thenReturn(true);
+    Room room = new Room();
+    room.setRoomId("!testRoom:matrix.meeds.tn");
+    room.setSpaceId("1");
+    when(matrixService.getRoomBySpace(space)).thenReturn(room);
+    response = mockMvc.perform(get(REST_PATH).with(simpleUser())
+            .param("spaceId", "1")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
+  }
+
+  @Test
+  void linkSpaceToRoom() throws Exception {
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/linkRoom").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isBadRequest());
+    response = mockMvc.perform(get(REST_PATH + "/linkRoom").with(simpleUser())
+            .param("spaceGroupId", "groupOne")
+            .param("roomId", "!roomIdenitifier:matrix.meeds.tn")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isNotFound());
+    Space space = new Space();
+    space.setAvatarUrl("/avatar/of/the/space");
+    space.setDisplayName("Test space");
+    when(spaceService.getSpaceByGroupId("/spaces/groupOne")).thenReturn(space);
+    response = mockMvc.perform(get(REST_PATH + "/linkRoom").with(simpleUser())
+            .param("spaceGroupId", "groupOne")
+            .param("roomId", "!roomIdenitifier:matrix.meeds.tn")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
+  }
+
+  @Test
+  void getByRoomId() throws Exception {
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/byRoomId").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isBadRequest());
+
+    response = mockMvc.perform(get(REST_PATH + "/byRoomId").with(simpleUser())
+            .param("roomId", "!roomIdentifier")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isForbidden());
+
+    Room room = new Room();
+    room.setRoomId("!testRoom:matrix.meeds.tn");
+    room.setSpaceId("1");
+    when(matrixService.getById("!testRoom:matrix.meeds.tn")).thenReturn(room);
+    when(matrixService.canAccess(room, SIMPLE_USER)).thenReturn(true);
+    response = mockMvc.perform(get(REST_PATH + "/byRoomId").with(simpleUser())
+            .param("roomId", "!testRoom:matrix.meeds.tn")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
+  }
+
+  @Test
+  void getUserDirectMessagingRooms() throws Exception {
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/dmRooms").with(simpleUser()).contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isBadRequest());
+
+    response = mockMvc.perform(get(REST_PATH + "/dmRooms").with(simpleUser())
+            .param("user", "john")
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
+    response.andExpect(content().string("{}"));
+
+    Room room = new Room();
+    room.setRoomId("!ThisIsARoom:matrix.meeds.tn");
+    room.setSpaceId(null);
+    room.setFirstParticipant("userOne");
+    room.setSecondParticipant(SIMPLE_USER);
+    when(matrixService.getMatrixDMRoomsOfUser(SIMPLE_USER)).thenReturn(Collections.singletonList(room));
+
+    Identity userIdentity = new Identity();
+    userIdentity.setRemoteId("userOne");
+    userIdentity.setId("1");
+    Profile profile = new Profile(userIdentity);
+    profile.getProperties().put(USER_MATRIX_ID, "userOne");
+    userIdentity.setProfile(profile);
+    when(identityManager.getOrCreateUserIdentity("userOne")).thenReturn(userIdentity);
+
+    response = mockMvc.perform(get(REST_PATH + "/dmRooms").with(simpleUser())
+            .param("user", SIMPLE_USER)
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
+    response.andExpect(content().string("{\"@userOne:matrix.meeds.tn\":[\"!ThisIsARoom:matrix.meeds.tn\"]}"));
+  }
+
+  @SneakyThrows
+  public static final String toJsonString(Object object) {
+    return OBJECT_MAPPER.writeValueAsString(object);
+  }
+
+  @SneakyThrows
+  public static final <T> T fromJsonString(String value, Class<T> resultClass) {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    return OBJECT_MAPPER.readValue(value, resultClass);
   }
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -805,6 +805,7 @@ export function sendMessage(payload, roomId) {
   let index = localStorage.getItem('matrix_transaction_index') || 1;
   const transactionId = `${new Date().getTime()}-${index}`;
   const eventType = 'm.room.message';
+  roomId = roomId.includes(matrixServerName) ? roomId : roomId + ":" + matrixServerName;
   return fetch(`/_matrix/client/v3/rooms/${roomId}/send/${eventType}/${transactionId}`, {
     method: 'PUT',
     headers: {


### PR DESCRIPTION
Depending on Matrix server performance, the rooms of the current user do not contain the full list. When creating a new space, the room is sometimes returned very late and the user can not send messages or interact on it.
The fix will check the list of rooms returned from Matrix server and will add the missing room after loading their identifiers from the Meeds database, in addition, it avoids issues when sending new messages on those rooms.
