### PR TITLE
fix: discussion avatar smashed when room name is long - MEED-9229 - Meeds-io/MIPs#164

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatDiscussionDrawer.vue
@@ -16,7 +16,7 @@
           <div
             :style="`backgroundImage: url(${room.avatarUrl})`"
             :class="avatarBorderClass"
-            class="meeds-chat-contact-avatar ma-0 size-9 d-flex">
+            class="flex-shrink-0 meeds-chat-contact-avatar ma-0 size-9 d-flex">
             <div
              v-if="room.directChat"
              :class="[presenceClass, avatarBorderClass]"


### PR DESCRIPTION
fix discussion avatar smashed when room name is long
