### PR TITLE
feat: disable space chat from the settings - MEED-9285 - Meeds-io/MIPs#164 (#251)

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,7 +34,7 @@
   </build>
 
   <properties>
-    <exo.test.coverage.ratio>0.4</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.53</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/io/meeds/chat/dao/MatrixRoomDAO.java
+++ b/services/src/main/java/io/meeds/chat/dao/MatrixRoomDAO.java
@@ -19,6 +19,7 @@
 package io.meeds.chat.dao;
 
 import io.meeds.chat.entity.RoomEntity;
+import io.meeds.chat.entity.RoomStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -45,6 +46,8 @@ public interface MatrixRoomDAO extends JpaRepository<RoomEntity, Long> {
   public RoomEntity findByRoomIdStartsWith(String roomId);
 
   public List<RoomEntity> findBySpaceIdIsNotNull();
+
+  public List<RoomEntity> findBySpaceIdIsNotNullAndStatusIs(RoomStatus status);
 
   public List<RoomEntity> findBySpaceIdIn(List<String> spaceIds);
 }

--- a/services/src/main/java/io/meeds/chat/entity/RoomEntity.java
+++ b/services/src/main/java/io/meeds/chat/entity/RoomEntity.java
@@ -49,7 +49,9 @@ public class RoomEntity implements Serializable {
   @Column(name = "SECOND_PARTICIPANT")
   public String             secondParticipant;
 
-
+  @Enumerated(EnumType.ORDINAL)
+  @Column(name = "STATUS")
+  public RoomStatus         status           = RoomStatus.ENABLED;
 
   public Long getId() {
     return id;
@@ -89,5 +91,13 @@ public class RoomEntity implements Serializable {
 
   public void setSecondParticipant(String secondParticipant) {
     this.secondParticipant = secondParticipant;
+  }
+
+  public RoomStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(RoomStatus status) {
+    this.status = status;
   }
 }

--- a/services/src/main/java/io/meeds/chat/entity/RoomStatus.java
+++ b/services/src/main/java/io/meeds/chat/entity/RoomStatus.java
@@ -1,0 +1,5 @@
+package io.meeds.chat.entity;
+
+public enum RoomStatus {
+    ENABLED, DISABLED, ENABLE_IN_PROGRESS, DISABLED_IN_PROGRESS
+}

--- a/services/src/main/java/io/meeds/chat/model/Room.java
+++ b/services/src/main/java/io/meeds/chat/model/Room.java
@@ -22,13 +22,15 @@ import lombok.Data;
 
 @Data
 public class Room {
-  private long   id;
+  private long    id;
 
-  private String roomId;
+  private String  roomId;
 
-  private String spaceId;
+  private String  spaceId;
 
-  private String firstParticipant;
+  private String  firstParticipant;
 
-  private String secondParticipant;
+  private String  secondParticipant;
+
+  private String  status;
 }

--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -22,6 +22,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.meeds.chat.entity.RoomStatus;
 import io.meeds.chat.model.Room;
 import io.meeds.chat.rest.model.*;
 import io.meeds.chat.service.MatrixSynchronizationService;
@@ -38,8 +39,12 @@ import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.api.notification.service.storage.NotificationService;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
@@ -49,8 +54,6 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.social.rest.api.RestUtils;
-import org.exoplatform.social.rest.entity.IdentityEntity;
 import org.exoplatform.ws.frameworks.json.impl.JsonGeneratorImpl;
 import org.exoplatform.ws.frameworks.json.value.JsonValue;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,8 +67,6 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.*;
 
 import static io.meeds.chat.service.utils.MatrixConstants.*;
-import static org.exoplatform.social.rest.api.EntityBuilder.IDENTITIES_TYPE;
-import static org.exoplatform.social.rest.api.EntityBuilder.buildEntityProfile;
 
 @RestController
 @RequestMapping("/matrix")
@@ -221,11 +222,9 @@ public class MatrixRest implements ResourceContainer {
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public boolean linkSpaceToRoom(@RequestParam("spaceGroupId")
-                                 String spaceGroupId,
-                                 @RequestParam(name = "roomId")
-                                 String roomId,
-                                 @RequestParam(name = "create", required = false)
-                                 Boolean create) {
+  String spaceGroupId, @RequestParam(name = "roomId")
+  String roomId, @RequestParam(name = "create", required = false)
+  Boolean create) {
     if (StringUtils.isBlank(spaceGroupId)) {
       LOG.error("Could not connect the space to a team, space name is missing");
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "space group Id is required");
@@ -240,8 +239,7 @@ public class MatrixRest implements ResourceContainer {
     Room room = matrixService.getRoomBySpace(space);
     if (room != null && StringUtils.isNotBlank(room.getRoomId())) {
       throw new ResponseStatusException(HttpStatus.CONFLICT,
-                                        "space with group Id " + spaceGroupId + "has already a room with ID "
-                                            + room.getRoomId());
+                                        "space with group Id " + spaceGroupId + "has already a room with ID " + room.getRoomId());
     }
 
     if (StringUtils.isBlank(roomId) && create) {
@@ -250,8 +248,8 @@ public class MatrixRest implements ResourceContainer {
       } catch (Exception e) {
         LOG.error("Could not link space {} to Matrix room {}", spaceGroupId, roomId, e);
         throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                "Could not link space " + spaceGroupId + " to Matrix room " + roomId + " : "
-                        + e.getMessage());
+                                          "Could not link space " + spaceGroupId + " to Matrix room " + roomId + " : "
+                                              + e.getMessage());
       }
     }
 
@@ -266,8 +264,8 @@ public class MatrixRest implements ResourceContainer {
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public Map<String, String[]> getUserDirectMessagingRooms(@Parameter(description = "The user")
-                                                           @RequestParam(name = "user")
-                                                           String user) {
+  @RequestParam(name = "user")
+  String user) {
 
     Map<String, String[]> userDMRooms = new HashMap<>();
     List<Room> rooms = matrixService.getMatrixDMRoomsOfUser(user);
@@ -332,7 +330,7 @@ public class MatrixRest implements ResourceContainer {
                                                 @Parameter(description = "The room Id")
                                                 @RequestParam(name = "roomId")
                                                 String roomId) {
-    if(StringUtils.isBlank(roomId)) {
+    if (StringUtils.isBlank(roomId)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "roomId parameter is required");
     }
     String userName = request.getRemoteUser();
@@ -360,7 +358,12 @@ public class MatrixRest implements ResourceContainer {
     if (space == null) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
-    Room room = matrixService.getRoomBySpace(space);
+    Room room;
+    if (spaceService.canManageSpace(space, userName)) {
+      room = matrixService.getRoomBySpace(space, true);
+    } else {
+      room = matrixService.getRoomBySpace(space);
+    }
 
     if (room == null) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
@@ -421,14 +424,10 @@ public class MatrixRest implements ResourceContainer {
 
   @GetMapping("participant/{userId}")
   @Secured("users")
-  @Operation(
-          summary = "Get participant info including its created matrix id using its user Id",
-          method = "GET",
-          description = "Get participant info including its created matrix id using its user Id")
-  @ApiResponses(value = {
-          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-          @ApiResponse(responseCode = "404", description = "User not found"),
-          @ApiResponse(responseCode = "500", description = "Internal server error") })
+  @Operation(summary = "Get participant info including its created matrix id using its user Id", method = "GET", description = "Get participant info including its created matrix id using its user Id")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "404", description = "User not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
   public ResponseEntity<?> getParticipantInfo(@PathVariable("userId")
   String userId) {
     try {
@@ -440,6 +439,88 @@ public class MatrixRest implements ResourceContainer {
       LOG.error("Could not get participant info of userId: {}", userId, e);
       return ResponseEntity.internalServerError().build();
     }
+  }
+
+  @PutMapping("enable/{spaceId}")
+  @Secured("users")
+  @Operation(summary = "Enable the chat for a given space", method = "GET", description = "Enable the chat for a space ")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "404", description = "User not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
+  public ResponseEntity<String> enableChat(HttpServletRequest request, @PathVariable("spaceId")
+  String spaceId) {
+    String currentUserName = request.getRemoteUser();
+
+    if (StringUtils.isBlank(spaceId)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Space id is mandatory");
+    }
+    Space space = spaceService.getSpaceById(spaceId);
+    if (!spaceService.canManageSpace(space, currentUserName)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                        "Current user does not have the needed privileges to enable the chat of the space");
+    }
+    Room roomToEnable = matrixService.getRoomBySpace(space, true);
+    class EnableChatRunnable implements Runnable {
+      @Override
+      public void run() {
+        ExoContainerContext.setCurrentContainer(PortalContainer.getInstance());
+        RequestLifeCycle.begin(PortalContainer.getInstance());
+        try {
+          matrixService.enableSpaceChat(space, true);
+        } catch (ObjectNotFoundException e) {
+          LOG.error("Could not enable the room {} of the space {}", roomToEnable.getRoomId(), space.getDisplayName(), e);
+          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                  "Could not enable the chat for the space with id " + spaceId);
+        } finally {
+          RequestLifeCycle.end();
+        }
+      }
+    }
+    Thread enableThread = new Thread(new EnableChatRunnable(), "Enable members in space Thread");
+    enableThread.start();
+    roomToEnable.setStatus(RoomStatus.ENABLE_IN_PROGRESS.name());
+    return ResponseEntity.ok().build();
+  }
+
+  @PutMapping("disable/{spaceId}")
+  @Secured("users")
+  @Operation(summary = "Enable the chat for a given space", method = "GET", description = "Enable the chat for a space ")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "404", description = "User not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
+  public ResponseEntity<String> disableChat(HttpServletRequest request, @PathVariable("spaceId")
+  String spaceId) {
+    String currentUserName = request.getRemoteUser();
+
+    if (StringUtils.isBlank(spaceId)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Space id is mandatory");
+    }
+    Space space = spaceService.getSpaceById(spaceId);
+    if (!spaceService.canManageSpace(space, currentUserName)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+              "Current user does not have the needed privileges to enable the chat of the space");
+    }
+    Room roomToEnable = matrixService.getRoomBySpace(space, true);
+    class EnableChatRunnable implements Runnable {
+      @Override
+      public void run() {
+        ExoContainerContext.setCurrentContainer(PortalContainer.getInstance());
+        RequestLifeCycle.begin(PortalContainer.getInstance());
+        try {
+          matrixService.enableSpaceChat(space, false);
+        } catch (ObjectNotFoundException e) {
+          LOG.error("Could not enable the room {} of the space {}", roomToEnable.getRoomId(), space.getDisplayName(), e);
+          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                  "Could not enable the chat for the space with id " + spaceId);
+        } finally {
+          RequestLifeCycle.end();
+        }
+      }
+    }
+    Thread disableThread = new Thread(new EnableChatRunnable(), "Disable members in space Thread");
+    disableThread.start();
+    roomToEnable.setStatus(RoomStatus.DISABLED_IN_PROGRESS.name());
+    return ResponseEntity.ok().build();
   }
 
   private void sendPushNotification(String participant, String roomId, int unreadCount) {
@@ -456,24 +537,15 @@ public class MatrixRest implements ResourceContainer {
     return String.valueOf(jws.getBody().getSubject());
   }
 
-  private IdentityEntity buildIdentityEntity(Identity identity, String restPath, String expand) {
-    IdentityEntity identityEntity = new IdentityEntity(identity.getId());
-    identityEntity.setHref(RestUtils.getRestUrl(IDENTITIES_TYPE, identity.getId(), restPath));
-    identityEntity.setProviderId(identity.getProviderId());
-    identityEntity.setRemoteId(identity.getRemoteId());
-    identityEntity.setDeleted(identity.isDeleted());
-    identityEntity.setProfile(buildEntityProfile(identity.getProfile(), restPath, expand));
-    return identityEntity;
-  }
-
   private RoomEntity buildRoomEntityFromRoom(Room room, String currentUserName) {
     RoomEntity roomEntity = new RoomEntity();
     String roomId = room.getRoomId();
     String serverName = PropertyManager.getProperty(MATRIX_SERVER_NAME);
-    if(!roomId.contains(serverName)) {
+    if (!roomId.contains(serverName)) {
       roomId = roomId + ":" + serverName;
     }
     roomEntity.setId(roomId);
+    roomEntity.setStatus(room.getStatus());
     if (StringUtils.isNotBlank(room.getSpaceId())) {
       roomEntity.setSpaceId(room.getSpaceId());
       roomEntity.setDirectChat(false);
@@ -487,8 +559,7 @@ public class MatrixRest implements ResourceContainer {
       }
     }
     // Update room entity with data from Meeds server
-    updateRoomEntity(roomEntity, currentUserName);
-    return roomEntity;
+    return updateRoomEntity(roomEntity, currentUserName);
   }
 
   /**
@@ -508,23 +579,33 @@ public class MatrixRest implements ResourceContainer {
 
     List<String> spaceIds = spaceService.getMemberSpacesIds(currentUserName, 0, -1);
 
-    for (RoomEntity room : roomList.getRooms()) {
-      updateRoomEntity(room, currentUserName);
-      //check missing rooms
-      if(!room.isDirectChat()) {
-        spaceIds.remove(room.getSpaceId());
+    List<RoomEntity> processedRooms = new ArrayList<>();
+    for (int index = 0; index < roomList.getRooms().size(); index ++) {
+      RoomEntity room = roomList.getRooms().get(index);
+      room = updateRoomEntity(room, currentUserName);
+      // check missing rooms
+      if (room != null) {
+        if(!room.isDirectChat()) {
+          spaceIds.remove(room.getSpaceId());
+        }
+        if (RoomStatus.ENABLED.name().equals(room.getStatus())) {
+          processedRooms.add(room);
+        }
       }
     }
-    if(!spaceIds.isEmpty()) {
-      for(String spaceId : spaceIds) {
+    if (!spaceIds.isEmpty()) {
+      for (String spaceId : spaceIds) {
         Room missingRoom = matrixService.getRoomBySpaceId(spaceId);
-        if(missingRoom != null) {
+        if (missingRoom != null) {
           RoomEntity missingRoomEntity = buildRoomEntityFromRoom(missingRoom, currentUserName);
-          roomList.getRooms().addFirst(missingRoomEntity);
+          if(missingRoomEntity != null) {
+            processedRooms.addFirst(missingRoomEntity);
+          }
         }
       }
     }
 
+    roomList.setRooms(processedRooms);
     return roomList;
   }
 
@@ -534,7 +615,7 @@ public class MatrixRest implements ResourceContainer {
     if (room.getId().contains(":")) {
       roomId = room.getId().substring(0, room.getId().indexOf(":"));// remove server part
     }
-    Room matrixRoom = matrixService.getById(roomId);
+    Room matrixRoom = matrixService.getById(roomId, true);
     if (matrixRoom != null) {
       if (StringUtils.isNotBlank(matrixRoom.getSpaceId())) {
         Space space = spaceService.getSpaceById(matrixRoom.getSpaceId());
@@ -549,7 +630,7 @@ public class MatrixRest implements ResourceContainer {
           room.setMembers(members);
         }
       } else if (StringUtils.isNotBlank(matrixRoom.getFirstParticipant())
-          && StringUtils.isNotBlank(matrixRoom.getSecondParticipant())) {
+              && StringUtils.isNotBlank(matrixRoom.getSecondParticipant())) {
         Identity identity = null;
         if (matrixRoom.getFirstParticipant().equals(currentUserName)) {
           identity = identityManager.getOrCreateUserIdentity(matrixRoom.getSecondParticipant());
@@ -568,14 +649,17 @@ public class MatrixRest implements ResourceContainer {
           room.setMatrixId((String) identity.getProfile().getProperty(USER_MATRIX_ID));
         }
       }
+      room.setStatus(matrixRoom.getStatus());
+      // Add update Date
+      if (room.getUpdated() == 0) {
+        room.setUpdated(System.currentTimeMillis());
+      }
+      return room;
+    } else {
+      return null;
     }
-    // Add update Date
-    if (room.getUpdated() == 0) {
-      room.setUpdated(System.currentTimeMillis());
-    }
-    return room;
   }
-  
+
   private Member buildRoomMember(String userName) {
     Identity identity = identityManager.getOrCreateUserIdentity(userName);
     if (identity == null || identity.getProfile() == null) {

--- a/services/src/main/java/io/meeds/chat/rest/model/RoomEntity.java
+++ b/services/src/main/java/io/meeds/chat/rest/model/RoomEntity.java
@@ -64,6 +64,8 @@ public class RoomEntity implements Serializable {
 
   private boolean      external;
 
+  private String       status;
+
   private List<Member> members;
 
 }

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -20,18 +20,18 @@ package io.meeds.chat.service;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.meeds.chat.entity.RoomStatus;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import io.meeds.chat.model.Room;
-import io.meeds.chat.rest.model.RoomList;
 import io.meeds.chat.service.utils.MatrixHttpClient;
 import io.meeds.chat.storage.MatrixRoomStorage;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.PropertyManager;
 
 import org.exoplatform.services.log.ExoLogger;
@@ -41,14 +41,14 @@ import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
+import org.exoplatform.ws.frameworks.json.impl.JsonGeneratorImpl;
+import org.exoplatform.ws.frameworks.json.value.JsonValue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -111,6 +111,7 @@ public class MatrixService {
 
       String userFullMatrixID = "@" + PropertyManager.getProperty(MATRIX_ADMIN_USERNAME) + ":"
           + PropertyManager.getProperty(MATRIX_SERVER_NAME);
+      this.overrideAdminRateLimit(userFullMatrixID);
       String displayName = System.getProperty(MATRIX_ADMIN_DISPLAY_NAME, "Chat Bot");
       if (StringUtils.isNotBlank(displayName)) {
         this.updateUserDisplayName(userFullMatrixID, displayName);
@@ -158,6 +159,17 @@ public class MatrixService {
   public Room getRoomBySpace(Space space) {
     return getRoomBySpaceId(space.getId());
   }
+
+  /**
+   * Returns the ID of the room linked to a space
+   *
+   * @param space the space
+   * @return the roomId linked to the space
+   */
+  public Room getRoomBySpace(Space space, boolean includeDisabled) {
+    return getRoomBySpaceId(space.getId(), includeDisabled);
+  }
+
   /**
    * Returns the ID of the room linked to a space
    *
@@ -165,7 +177,17 @@ public class MatrixService {
    * @return the roomId linked to the space
    */
   public Room getRoomBySpaceId(String spaceId) {
-    return matrixRoomStorage.getMatrixRoomBySpaceId(spaceId);
+    return this.getRoomBySpaceId(spaceId, false);
+  }
+
+  /**
+   * Returns the ID of the room linked to a space
+   *
+   * @param spaceId the space Id
+   * @return the roomId linked to the space
+   */
+  public Room getRoomBySpaceId(String spaceId, boolean includeDisabled) {
+    return matrixRoomStorage.getMatrixRoomBySpaceId(spaceId, includeDisabled);
   }
 
   /**
@@ -175,8 +197,19 @@ public class MatrixService {
    * @return Room
    */
   public Room getById(String roomId) {
+    return this.getById(roomId, false);
+  }
+
+  /**
+   * Get a room by its technical ID
+   *
+   * @param roomId the room technical ID
+   * @param includeDisabled return room even if it is disabled
+   * @return Room
+   */
+  public Room getById(String roomId, boolean includeDisabled) {
     roomId = extractRoomId(roomId);
-    return matrixRoomStorage.getById(roomId);
+    return matrixRoomStorage.getById(roomId, includeDisabled);
   }
 
   /**
@@ -239,6 +272,7 @@ public class MatrixService {
 
   /**
    * Saves a new user on Matrix
+   * 
    * @param user the user identity
    * @param isNew if the user has been just created
    * @return the matrix user ID
@@ -246,8 +280,7 @@ public class MatrixService {
    * @throws IOException
    * @throws InterruptedException
    */
-  public String saveUserAccount(Identity user,
-                                boolean isNew) throws JsonException, IOException, InterruptedException {
+  public String saveUserAccount(Identity user, boolean isNew) throws JsonException, IOException, InterruptedException {
     return saveUserAccount(user, isNew, false, true);
   }
 
@@ -403,10 +436,6 @@ public class MatrixService {
     return matrixRoomId;
   }
 
-  public long getAllLinkedRooms() {
-    return matrixRoomStorage.getSpaceRoomCount();
-  }
-
   public Room getDirectMessagingRoom(String firstParticipant, String secondParticipant) {
     return matrixRoomStorage.getDirectMessagingRoom(firstParticipant, secondParticipant);
   }
@@ -477,6 +506,7 @@ public class MatrixService {
     }
     return fullMatrixUserId;
   }
+
   /**
    * Extracts the room ID from the full room Id on Matrix
    *
@@ -524,11 +554,87 @@ public class MatrixService {
   }
 
   /**
-   * Load the list of space rooms
-   * @param spaceIds : list of space IDs
-   * @return List of Rooms
+   * Enable the chat for the space
+   *
+   * @param space the space where the chat will be disabled/enabled
+   * @param enable true to enable the room, false to disable it
+   * @return Room the updated room
    */
-  public List<Room> getSpaceRoomsBySpaceIds(List<String> spaceIds) {
-    return matrixRoomStorage.getSpaceRoomsBySpaceIds(spaceIds);
+  public Room enableSpaceChat(Space space, boolean enable) throws ObjectNotFoundException {
+    if (space == null) {
+      throw new IllegalArgumentException("The space should not be null");
+    }
+    Room spaceRoom = this.getRoomBySpace(space, true);
+    if (spaceRoom == null) {
+      throw new ObjectNotFoundException("Could not find a chat room for the space " + space.getDisplayName());
+    }
+    String matrixAdminUsername = PropertyManager.getProperty(MATRIX_ADMIN_USERNAME);
+
+    RoomStatus currentRoomStatus = RoomStatus.valueOf(spaceRoom.getStatus());
+    this.changeRoomStatus(spaceRoom.getRoomId(), enable ? RoomStatus.ENABLE_IN_PROGRESS : RoomStatus.DISABLED_IN_PROGRESS);
+    try {
+      for (String member : space.getMembers()) {
+        String matrixIdOfMember = getMatrixIdForUser(member);
+        if (!matrixAdminUsername.equals(matrixIdOfMember)) {
+          try {
+            if (enable) {
+              joinUserToRoom(spaceRoom.getRoomId(), matrixIdOfMember);
+            } else {
+              kickUserFromRoom(spaceRoom.getRoomId(),
+                      matrixIdOfMember,
+                      "the Chat was disabled for the space %s, thus the user %s is removed from the chat members".formatted(space.getDisplayName(),
+                              member));
+            }
+          } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+            }
+            LOG.error("couldn't invite / remove the user {} from the room {}", matrixAdminUsername, spaceRoom.getRoomId(), e);
+          }
+        }
+      }
+      spaceRoom = this.changeRoomStatus(spaceRoom.getRoomId(), enable ? RoomStatus.ENABLED : RoomStatus.DISABLED);
+    } catch (Exception e) {
+      // reset room to original status
+      spaceRoom = this.changeRoomStatus(spaceRoom.getRoomId(), currentRoomStatus);
+      LOG.error("An error occurred when enabling/disabling the room {}", matrixAdminUsername, spaceRoom.getRoomId(), e);
+    }
+    return spaceRoom;
+  }
+
+  /**
+   * Enable or disable a room
+   * 
+   * @param roomId the ID of the Chat room
+   * @param status the status to set: ENABLED, DISABLED, ENABLE_IN_PROGRESS,
+   *          DISABLED_IN_PROGRESS
+   * @return Room the updated room
+   */
+  private Room changeRoomStatus(String roomId, RoomStatus status) {
+    return matrixRoomStorage.setRoomEnabled(roomId, status);
+  }
+
+  /**
+   * Overrides the rate limits for the current administrator to unlimited
+   * 
+   * @param adminUserId the admin username on Matrix
+   */
+  public void overrideAdminRateLimit(String adminUserId) {
+    try {
+      String currentRateLimits = matrixHttpClient.getOverriddenRateLimitForUser(adminUserId, getMatrixAccessToken());
+      JsonValue currentLimits = new JsonGeneratorImpl().createJsonObjectFromString(currentRateLimits);
+      JsonValue messagePerSecond = currentLimits.getElement("messages_per_second");
+      JsonValue burstCount = currentLimits.getElement("burst_count");
+      if (messagePerSecond == null || burstCount == null || messagePerSecond.getIntValue() > 0 || burstCount.getIntValue() > 0) {
+        // set the messages per second to zero -> unlimited
+        // set the burst count to 0 : No burst count
+        matrixHttpClient.overrideRateLimitForUser(adminUserId, 0, 0, getMatrixAccessToken());
+      }
+    } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      LOG.error("Could not update the rate limits for the Matrix admin user", e);
+    }
   }
 }

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -385,10 +385,10 @@ public class MatrixHttpClient {
         String fullMatrixID = userAccount.getElement("name").getStringValue();
         // If the user is a new user, we need to authenticate him
         if (isNew) {
-          String accessTokenOfCreatedUser = authenticateUser(matrixUserId, password);
+          authenticateUser(matrixUserId, password);
           LOG.info("User {} authenticated successfully", user.getRemoteId());
         }
-        return fullMatrixID.substring(1, fullMatrixID.indexOf(":"));
+        return fullMatrixID.contains(":") ? fullMatrixID.substring(1, fullMatrixID.indexOf(":")) : fullMatrixID;
       } else {
         throw new RuntimeException("Error creating a user account, Matrix server returned HTTP %s error %s".formatted(response.statusCode(),
                                                                                                                       response.body()));
@@ -1018,6 +1018,71 @@ public class MatrixHttpClient {
                                                                                                                                      String.valueOf(response.statusCode()),
                                                                                                                                      response.body()));
       }
+    }
+  }
+
+  /**
+   * Overrides the rate limits for a given user
+   * @param userIdOnMatrix the user Id on Matrix
+   * @param messagesPerSecond the allowed number of messages per second
+   * @param burstCount how many actions that can be performed before being limited
+   * @param accessToken the access token
+   * @return String the applied rate limits configuration
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public String overrideRateLimitForUser(String userIdOnMatrix,
+                                          int messagesPerSecond,
+                                          int burstCount,
+                                          String accessToken) throws IOException, InterruptedException {
+    if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
+      throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
+    }
+    String encodedUserMatrixId = URLEncoder.encode(userIdOnMatrix, StandardCharsets.UTF_8);
+    String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_synapse/admin/v1/users/" + encodedUserMatrixId
+        + "/override_ratelimit";
+
+    String payload = """
+        {
+          "messages_per_second": %s,
+          "burst_count": %s
+        }
+        """.formatted(messagesPerSecond, burstCount);
+
+    HttpResponse<String> response = sendHttpPostRequest(url, accessToken, payload);
+    if (response.statusCode() >= 200 && response.statusCode() < 300) {
+      return response.body();
+    } else {
+      throw new RuntimeException("Error overriding the rate limits for the user %s ,Matrix server returned HTTP %s error %s".formatted(userIdOnMatrix,
+                                                                                                                                       String.valueOf(response.statusCode()),
+                                                                                                                                       response.body()));
+    }
+  }
+
+  /**
+   * Gets the overridden the rate limits for a given user
+   * @param userIdOnMatrix the user Id on Matrix
+   * @param accessToken the access token
+   * @return String the applied rate limits configuration
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public String getOverriddenRateLimitForUser(String userIdOnMatrix, String accessToken) throws IOException,
+                                                                                         InterruptedException {
+    if (StringUtils.isBlank(PropertyManager.getProperty(MATRIX_SERVER_URL))) {
+      throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
+    }
+    String encodedUserMatrixId = URLEncoder.encode(userIdOnMatrix, StandardCharsets.UTF_8);
+    String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_synapse/admin/v1/users/" + encodedUserMatrixId
+        + "/override_ratelimit";
+
+    HttpResponse<String> response = sendHttpGetRequest(url, accessToken);
+    if (response.statusCode() >= 200 && response.statusCode() < 300) {
+      return response.body();
+    } else {
+      throw new RuntimeException("Error overriding the rate limits for the user %s ,Matrix server returned HTTP %s error %s".formatted(userIdOnMatrix,
+                                                                                                                                       String.valueOf(response.statusCode()),
+                                                                                                                                       response.body()));
     }
   }
 }

--- a/services/src/main/java/io/meeds/chat/storage/MatrixRoomStorage.java
+++ b/services/src/main/java/io/meeds/chat/storage/MatrixRoomStorage.java
@@ -19,6 +19,7 @@
 package io.meeds.chat.storage;
 
 import io.meeds.chat.dao.MatrixRoomDAO;
+import io.meeds.chat.entity.RoomStatus;
 import io.meeds.chat.model.Room;
 import io.meeds.chat.entity.RoomEntity;
 import org.apache.commons.lang3.StringUtils;
@@ -42,33 +43,13 @@ public class MatrixRoomStorage {
   @Autowired
   private SpaceService     spaceService;
 
-  public Room getMatrixRoomBySpaceId(String spaceId) {
+  public Room getMatrixRoomBySpaceId(String spaceId, boolean includeDisabled) {
     RoomEntity roomEntity = matrixRoomDAO.findBySpaceId(spaceId);
-    if (roomEntity != null) {
+    if (roomEntity != null && (roomEntity.getStatus().equals(RoomStatus.ENABLED)
+        || includeDisabled)) {
       return toRoomModel(roomEntity);
     } else {
       LOG.warn("Can not find an associated matrix room for the space with ID {}", spaceId);
-      return null;
-    }
-  }
-
-  public Space getSpaceIdByMatrixRoomId(String roomId) {
-    RoomEntity roomEntity = matrixRoomDAO.findByRoomId(roomId);
-    if (roomEntity != null && StringUtils.isNotBlank(roomEntity.getSpaceId())) {
-      return spaceService.getSpaceById(String.valueOf(roomEntity.getSpaceId()));
-    } else {
-      LOG.warn("Can not find an associated space for the matrix room with ID {}", roomId);
-      return null;
-    }
-  }
-
-  public Room getDMRoomByRoomId(String roomId) {
-    RoomEntity roomEntity = matrixRoomDAO.findByRoomId(roomId);
-    if (roomEntity != null && StringUtils.isNotBlank(roomEntity.getFirstParticipant())
-        && StringUtils.isNotBlank(roomEntity.getSecondParticipant())) {
-      return toRoomModel(roomEntity);
-    } else {
-      LOG.warn("Can not find an associated space for the matrix room with ID {}", roomId);
       return null;
     }
   }
@@ -96,10 +77,6 @@ public class MatrixRoomStorage {
     return rooms;
   }
 
-  public long getSpaceRoomCount() {
-    return matrixRoomDAO.count();
-  }
-
   public Room getDirectMessagingRoom(String firstParticipantId, String secondParticipantId) {
     RoomEntity directMessagingRoom = matrixRoomDAO.findByFirstParticipantAndSecondParticipant(firstParticipantId,
                                                                                               secondParticipantId);
@@ -122,9 +99,10 @@ public class MatrixRoomStorage {
     matrixRoomDAO.delete(roomEntity);
   }
 
-  public Room getById(String roomId) {
+  public Room getById(String roomId, boolean includeDisabled) {
     RoomEntity roomEntity = matrixRoomDAO.findByRoomIdStartsWith(roomId);
-    if(roomEntity != null) {
+    if (roomEntity != null && (roomEntity.getStatus().equals(RoomStatus.ENABLED)
+        || (includeDisabled && roomEntity.getStatus().equals(RoomStatus.DISABLED)))) {
       return toRoomModel(roomEntity);
     }
     return null;
@@ -143,6 +121,7 @@ public class MatrixRoomStorage {
     room.setSpaceId(roomEntity.getSpaceId());
     room.setFirstParticipant(roomEntity.getFirstParticipant());
     room.setSecondParticipant(roomEntity.getSecondParticipant());
+    room.setStatus(roomEntity.getStatus().name());
     return room;
   }
 
@@ -152,15 +131,19 @@ public class MatrixRoomStorage {
    * @return List of SpaceRoom
    */
   public List<Room> getSpaceRooms() {
-    return toRoomList(matrixRoomDAO.findBySpaceIdIsNotNull());
+    return toRoomList(matrixRoomDAO.findBySpaceIdIsNotNullAndStatusIs(RoomStatus.ENABLED));
   }
 
   /**
-   * Load the list of space rooms
-   * @param spaceIds : list of space IDs
-   * @return List of Rooms
+   * Enable or disable a room
+   * 
+   * @param roomId the ID of the Chat room
+   * @param status the status to set: ENABLE, DISABLED, ENABLE_IN6PROGRESS, DISABLE_IN_PROGRESS
+   * @return the updated room
    */
-  public List<Room> getSpaceRoomsBySpaceIds(List<String> spaceIds) {
-    return toRoomList(matrixRoomDAO.findBySpaceIdIn(spaceIds));
+  public Room setRoomEnabled(String roomId, RoomStatus status) {
+    RoomEntity roomEntity = matrixRoomDAO.findByRoomId(roomId);
+    roomEntity.setStatus(status);
+    return toRoomModel(matrixRoomDAO.save(roomEntity));
   }
 }

--- a/services/src/main/resources/db/changelog/matrix-rdbms.db.changelog-master.xml
+++ b/services/src/main/resources/db/changelog/matrix-rdbms.db.changelog-master.xml
@@ -51,5 +51,12 @@
       <column name="SECOND_PARTICIPANT" type="VARCHAR(255)"/>
     </addColumn>
   </changeSet>
+  <changeSet id="1.0.0-4" author="matrix">
+    <addColumn tableName="MATRIX_ROOM">
+      <column name="STATUS" type="INT" defaultValueNumeric="0">
+        <constraints nullable="false" />
+      </column>
+    </addColumn>
+  </changeSet>
 
 </databaseChangeLog>

--- a/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
+++ b/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.meeds.chat.entity.RoomStatus;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import io.meeds.chat.model.Room;
 import io.meeds.chat.rest.model.*;
@@ -143,34 +144,57 @@ class MatrixRestTest {
     Room room1 = new Room();
     room1.setRoomId("!testRoom1:matrix.meeds.tn");
     room1.setSpaceId("1");
+    room1.setStatus(RoomStatus.ENABLED.name());
     Room room2 = new Room();
     room2.setRoomId("!testRoom2:matrix.meeds.tn");
     room2.setSpaceId("2");
+    room2.setStatus(RoomStatus.ENABLED.name());
     Room room3 = new Room();
     room3.setRoomId("!testRoom3:matrix.meeds.tn");
     room3.setSpaceId("3");
-    RoomList roomsList = new RoomList();
-    roomsList.setTotalUnreadMessages(5);
-    roomsList.setRooms(List.of(roomEntity1, roomEntity2));
+    room3.setStatus(RoomStatus.ENABLED.name());
+
+    when(matrixService.getById("!testRoom1", true)).thenReturn(room1);
     when(matrixService.getById("!testRoom1")).thenReturn(room1);
+    when(matrixService.getById("!testRoom2", true)).thenReturn(room2);
     when(matrixService.getById("!testRoom2")).thenReturn(room2);
+    when(matrixService.getById("!testRoom3", true)).thenReturn(room3);
     when(matrixService.getById("!testRoom3")).thenReturn(room3);
     Space space1 = new Space();
-    space1.setDisplayName("Space of Heroes");
+    space1.setDisplayName("Space of Heroes 1");
     space1.setAvatarUrl("/Url/Of/Avatar.png");
     space1.setMembers(new String[]{"user1", "user2"});
     when(spaceService.getSpaceById("1")).thenReturn(space1);
+    when(matrixService.getRoomBySpaceId("1")).thenReturn(room1);
     Space space2 = new Space();
-    space2.setDisplayName("Space of Heroes");
+    space2.setDisplayName("Space of Heroes 2");
     space2.setAvatarUrl("/Url/Of/Avatar.png");
     space2.setMembers(new String[]{"user1", "user2"});
     when(spaceService.getSpaceById("2")).thenReturn(space2);
+    when(matrixService.getRoomBySpaceId("2")).thenReturn(room2);
     Space space3 = new Space();
-    space3.setDisplayName("Space of Heroes");
+    space3.setDisplayName("Space of Heroes 3");
     space3.setAvatarUrl("/Url/Of/Avatar.png");
     space3.setMembers(new String[]{"user1", "user2"});
     when(spaceService.getSpaceById("3")).thenReturn(space3);
     when(matrixService.getRoomBySpaceId("3")).thenReturn(room3);
+
+    RoomEntity privateRoomEntity1 = createRoomEntity(4);
+    privateRoomEntity1.setDirectChat(true);
+    Room privateRoom1 = new Room();
+    privateRoom1.setRoomId("!testRoom4:matrix.meeds.tn");
+    privateRoom1.setSpaceId(null);
+    privateRoom1.setFirstParticipant(SIMPLE_USER);
+    privateRoom1.setSecondParticipant("user2");
+    privateRoom1.setStatus(RoomStatus.ENABLED.name());
+    createUserIdentity("user2");
+    when(matrixService.getById("!testRoom4", true)).thenReturn(privateRoom1);
+    when(matrixService.getById("!testRoom4")).thenReturn(privateRoom1);
+
+    RoomList roomsList = new RoomList();
+    roomsList.setTotalUnreadMessages(5);
+    roomsList.setRooms(List.of(roomEntity1, roomEntity2, privateRoomEntity1));
+
     when(spaceService.getMemberSpacesIds(SIMPLE_USER, 0, -1)).thenReturn(new ArrayList<>(List.of(new String [] {"1", "2", "3"})));
     ResultActions response = mockMvc.perform(post(REST_PATH + "/processRooms").with(simpleUser())
                                                                               .contentType(MediaType.APPLICATION_JSON)
@@ -181,7 +205,7 @@ class MatrixRestTest {
     RoomList expectedRoomList = fromJsonString(response.andReturn().getResponse().getContentAsString(), RoomList.class);
     assertNotNull(expectedRoomList);
     assertNotNull(expectedRoomList.getRooms());
-    assertEquals(3, expectedRoomList.getRooms().size());
+    assertEquals(4, expectedRoomList.getRooms().size());
     assertEquals(5, expectedRoomList.getTotalUnreadMessages());
 
     //
@@ -189,15 +213,7 @@ class MatrixRestTest {
     room.setSpaceId(null);
     room.setFirstParticipant("root");
     room.setSecondParticipant("user");
-    Identity identity = new Identity();
-    identity.setRemoteId("user");
-    identity.setId("1");
-    Profile profile = new Profile();
-    profile.setAvatarUrl("/avatar/of/root");
-    profile.setProperty("firstName", "User");
-    profile.setProperty("lastName", "Root");
-    identity.setProfile(profile);
-    when(identityManager.getOrCreateUserIdentity("root")).thenReturn(identity);
+    createUserIdentity("root");
 
     ResultActions response1 = mockMvc.perform(post(REST_PATH + "/processRooms").with(simpleUser())
                                                                                .contentType(MediaType.APPLICATION_JSON)
@@ -205,15 +221,16 @@ class MatrixRestTest {
     response1.andExpect(status().isOk());
   }
 
-  private RoomList createRoomsList(int numberOfRooms) {
-    List<RoomEntity> rooms = new ArrayList<>();
-    for (int i = 0; i < numberOfRooms; i++) {
-      rooms.add(createRoomEntity(i));
-    }
-    RoomList roomList = new RoomList();
-    roomList.setTotalUnreadMessages(20);
-    roomList.setRooms(rooms);
-    return roomList;
+  private void createUserIdentity(String userName) {
+    Identity identity = new Identity();
+    identity.setRemoteId(userName);
+    identity.setId("1");
+    Profile profile = new Profile();
+    profile.setAvatarUrl("/avatar/of/root");
+    profile.setProperty("firstName", userName);
+    profile.setProperty("lastName", "The king");
+    identity.setProfile(profile);
+    when(identityManager.getOrCreateUserIdentity(userName)).thenReturn(identity);
   }
 
   private RoomEntity createRoomEntity(int index) {
@@ -232,6 +249,7 @@ class MatrixRestTest {
     lastMessage.setContent("This is a new message");
     lastMessage.setSender("@root:matrix.meeds.tn");
     room.setLastMessage(lastMessage);
+    room.setStatus(RoomStatus.ENABLED.name());
     return room;
   }
 
@@ -419,15 +437,60 @@ class MatrixRestTest {
   }
 
   @SneakyThrows
-  public static final String toJsonString(Object object) {
-    return OBJECT_MAPPER.writeValueAsString(object);
-  }
-
-  @SneakyThrows
   public static final <T> T fromJsonString(String value, Class<T> resultClass) {
     if (StringUtils.isBlank(value)) {
       return null;
     }
     return OBJECT_MAPPER.readValue(value, resultClass);
+  }
+
+  @Test
+  void enableChat() throws Exception {
+    ResultActions response = mockMvc.perform(put(REST_PATH + "/enable/1").with(simpleUser())
+                                                                         .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isForbidden());
+
+    Space space1 = new Space();
+    space1.setId(1);
+    space1.setDisplayName("Space of Heroes");
+    space1.setAvatarUrl("/Url/Of/Avatar.png");
+    space1.setMembers(new String[]{"user1", "user2"});
+    Room room = new Room();
+    room.setRoomId("!testRoom:matrix.meeds.tn");
+    room.setSpaceId("1");
+    when(matrixService.enableSpaceChat(space1, true)).thenReturn(room);
+    when(matrixService.getRoomBySpace(space1, true)).thenReturn(room);
+
+    when(spaceService.getSpaceById("1")).thenReturn(space1);
+    when(spaceService.canManageSpace(space1, SIMPLE_USER)).thenReturn(true);
+
+    response = mockMvc.perform(put(REST_PATH + "/enable/1").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
+  }
+
+  @Test
+  void disableChat() throws Exception {
+    ResultActions response = mockMvc.perform(put(REST_PATH + "/disable/1").with(simpleUser())
+                                                                          .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isForbidden());
+
+    Space space1 = new Space();
+    space1.setId(1);
+    space1.setDisplayName("Space of Heroes");
+    space1.setAvatarUrl("/Url/Of/Avatar.png");
+    space1.setMembers(new String[]{"user1", "user2"});
+    Room room = new Room();
+    room.setRoomId("!testRoom:matrix.meeds.tn");
+    room.setSpaceId("1");
+    when(matrixService.enableSpaceChat(space1, false)).thenReturn(room);
+    when(matrixService.getRoomBySpace(space1, true)).thenReturn(room);
+
+    when(spaceService.getSpaceById("1")).thenReturn(space1);
+    when(spaceService.canManageSpace(space1, SIMPLE_USER)).thenReturn(true);
+
+    response = mockMvc.perform(put(REST_PATH + "/disable/1").with(simpleUser())
+            .contentType(MediaType.APPLICATION_JSON));
+    response.andExpect(status().isOk());
   }
 }

--- a/services/src/test/java/io/meeds/chat/service/MatrixServiceTest.java
+++ b/services/src/test/java/io/meeds/chat/service/MatrixServiceTest.java
@@ -1,6 +1,7 @@
 package io.meeds.chat.service;
 
 import io.meeds.chat.MatrixBaseTest;
+import io.meeds.chat.entity.RoomStatus;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import io.meeds.chat.model.MatrixUserPermission;
 import io.meeds.chat.model.Room;
@@ -13,6 +14,7 @@ import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.jpa.search.ProfileSearchConnector;
 import org.exoplatform.social.core.jpa.storage.RDBMSIdentityStorageImpl;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -63,7 +65,9 @@ class MatrixServiceTest extends MatrixBaseTest {
 
   private List<Space>    spacesToDelete = new ArrayList<>();
 
-  private String         matrixRoomId   = "!thisIsACreatedRoom:matrix.exo.tn";
+  private List<String>   roomsToDelete  = new ArrayList<>();
+
+  private String         matrixRoomId   = "!thisIsACreatedRoom:matrix.meeds.tn";
 
   private String         accessToken    = "ThisIsAnAccessToken";
 
@@ -86,7 +90,6 @@ class MatrixServiceTest extends MatrixBaseTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    getContainer();
     begin();
     PropertyManager.setProperty(MATRIX_ADMIN_USERNAME, "demo");
     when(profileSearchConnector.search(any(), any(), any(), anyLong(), anyLong())).thenReturn(List.of("1", "2"));
@@ -95,6 +98,7 @@ class MatrixServiceTest extends MatrixBaseTest {
     when(matrixHttpClient.getAdminAccessToken(anyString())).thenReturn(accessToken);
 
     when(matrixHttpClient.createRoom(anyString(), anyString(), anyString())).thenReturn(matrixRoomId);
+    when(matrixHttpClient.deleteRoom(anyString(), anyString())).thenReturn(true);
     MatrixUserPermission matrixUserPermission = new MatrixUserPermission();
     matrixUserPermission.setUserName("demo");
     matrixUserPermission.setUserRole(MANAGER_ROLE);
@@ -123,15 +127,23 @@ class MatrixServiceTest extends MatrixBaseTest {
         // Nothing to do
       }
     }
+    for (String roomId : roomsToDelete) {
+      try {
+        this.matrixService.deleteRoom(roomId);
+      } catch (Exception e) {
+        // Nothing to do
+      }
+    }
     end();
   }
 
   @Test
   void createRoom() throws Exception {
     Space space = getSpaceInstance(1);
-    String returnedMatrixRoomId = matrixService.createRoom(space);
-    assertNotNull(matrixRoomId);
-    assertEquals(matrixRoomId, returnedMatrixRoomId);
+    Room spaceRoom = matrixService.getRoomBySpace(space);
+    assertNotNull(spaceRoom);
+    roomsToDelete.add(spaceRoom.getRoomId());
+    assertEquals(matrixRoomId, spaceRoom.getRoomId());
   }
 
   private Space getSpaceInstance(int number) {
@@ -142,6 +154,10 @@ class MatrixServiceTest extends MatrixBaseTest {
     space.setDescription("add new space " + number);
     space.setVisibility(Space.PUBLIC);
     space.setRegistration(Space.VALIDATION);
+    Identity spaceIdentity = new Identity();
+    spaceIdentity.setRemoteId(space.getPrettyName());
+    spaceIdentity.setProviderId(SpaceIdentityProvider.NAME);
+    identityStorage.saveIdentity(spaceIdentity);
     Space createdSpace = this.spaceService.createSpace(space, "root");
     String[] managers = new String[] { "demo", "tom" };
     String[] members = new String[] { "demo", "raul", "ghost", "dragon" };
@@ -160,7 +176,7 @@ class MatrixServiceTest extends MatrixBaseTest {
   void updateUserPresence() throws JsonException, IOException, InterruptedException {
     when(matrixHttpClient.setUserPresence(anyString(), anyString(), anyString(), anyString())).thenReturn("online");
 
-    String presence = matrixService.updateUserPresence("@user:matrix.exo.tn", "online", "I am available");
+    String presence = matrixService.updateUserPresence("@user:matrix.meeds.tn", "online", "I am available");
     assertNotNull(presence);
     assertEquals("online", presence);
 
@@ -169,7 +185,7 @@ class MatrixServiceTest extends MatrixBaseTest {
                                           anyString(),
                                           anyString())).thenThrow(new JsonException("Error"));
 
-    presence = matrixService.updateUserPresence("@user:matrix.exo.tn", "online", "I am available");
+    presence = matrixService.updateUserPresence("@user:matrix.meeds.tn", "online", "I am available");
     assertNull(presence);
   }
 
@@ -205,6 +221,7 @@ class MatrixServiceTest extends MatrixBaseTest {
   void getRoomBySpace() throws Exception {
     Space space = getSpaceInstance(1);
     Room room = matrixService.getRoomBySpace(space);
+    roomsToDelete.add(room.getRoomId());
     assertNotNull(room);
     assertEquals(matrixRoomId, room.getRoomId());
   }
@@ -233,6 +250,8 @@ class MatrixServiceTest extends MatrixBaseTest {
   @Test
   void updateRoomAvatar() throws Exception {
     Space space = getSpaceInstance(1);
+    String roomId = matrixService.createRoom(space);
+    roomsToDelete.add(roomId);
     InputStream inputStream = getClass().getClassLoader().getResourceAsStream("meeds.png");
 
     AvatarAttachment attachment = new AvatarAttachment(null, "meeds.png", "image/png", inputStream, System.currentTimeMillis());
@@ -262,20 +281,54 @@ class MatrixServiceTest extends MatrixBaseTest {
     directMessagingRoom.setFirstParticipant("demo");
     directMessagingRoom.setSecondParticipant("raul");
     Room createdRoom = matrixService.createDirectMessagingRoom(directMessagingRoom);
+    roomsToDelete.add(createdRoom.getRoomId());
     assertNotNull(createdRoom);
     assertNotEquals(0, createdRoom.getId());
     assertEquals(directMessagingRoom.getRoomId(), createdRoom.getRoomId());
   }
 
-    @Test
-    void getById() throws Exception {
-      Space space = getSpaceInstance(1);
-      String roomId = matrixService.createRoom(space);
-      assertNotNull(roomId);
-      Room room = matrixService.getById(roomId);
-      assertNotNull(room);
-      String splitRoomId = roomId.substring(0, roomId.indexOf(":"));
-      Room room1 = matrixService.getById(splitRoomId);
-      assertNotNull(room1);
-    }
+  @Test
+  void getById() throws Exception {
+    Space space = getSpaceInstance(1);
+    String roomId = matrixService.createRoom(space);
+    roomsToDelete.add(roomId);
+    assertNotNull(roomId);
+    Room room = matrixService.getById(roomId);
+    assertNotNull(room);
+    String splitRoomId = roomId.substring(0, roomId.indexOf(":"));
+    Room room1 = matrixService.getById(splitRoomId);
+    assertNotNull(room1);
+  }
+
+  @Test
+  void enableSpaceChat() throws Exception {
+    Space space = getSpaceInstance(1);
+    roomsToDelete.add(matrixRoomId);
+    Room room = matrixService.getById(matrixRoomId);
+    assertEquals(room.getStatus(), RoomStatus.ENABLED.name());
+    matrixService.enableSpaceChat(space, false);
+    verify(matrixHttpClient, times(1)).kickUserFromRoom(anyString(), anyString(), anyString(), anyString());
+    matrixService.enableSpaceChat(space, true);
+    verify(matrixHttpClient, times(2)).joinUserToRoom(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void overrideAdminRateLimit() throws IOException, InterruptedException {
+    String admin = "admin";
+    when(matrixHttpClient.getOverriddenRateLimitForUser(admin, accessToken)).thenReturn("""
+                                                                                                          {
+                                                                                                            "messages_per_second": 0,
+                                                                                                            "burst_count": 0
+                                                                                                          }""");
+    matrixService.overrideAdminRateLimit(admin);
+    verify(matrixHttpClient, times(0)).overrideRateLimitForUser(admin, 0, 0, accessToken);
+
+    when(matrixHttpClient.getOverriddenRateLimitForUser(admin, accessToken)).thenReturn("""
+                                                                                                          {
+                                                                                                            "messages_per_second": 10,
+                                                                                                            "burst_count": 20
+                                                                                                          }""");
+    matrixService.overrideAdminRateLimit(admin);
+    verify(matrixHttpClient, times(1)).overrideRateLimitForUser(admin, 0, 0, accessToken);
+  }
 }

--- a/services/src/test/java/io/meeds/chat/service/utils/MatrixHttpClientTest.java
+++ b/services/src/test/java/io/meeds/chat/service/utils/MatrixHttpClientTest.java
@@ -1,8 +1,13 @@
 package io.meeds.chat.service.utils;
 
+import io.meeds.chat.model.Events;
+import io.meeds.chat.model.MatrixRoomPermissions;
+import io.meeds.chat.model.MatrixUserPermission;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.impl.UserImpl;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +16,9 @@ import org.mockito.MockedStatic;
 
 import java.io.IOException;
 import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static io.meeds.chat.service.utils.MatrixConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,6 +38,8 @@ class MatrixHttpClientTest {
   HttpResponse<String>     responseTooManyRequests;
 
   MatrixHttpClient         matrixHttpClient = new MatrixHttpClient();
+
+  private HttpResponse     responseNotOK;
 
   @Test
   void getAdminAccessToken() throws JsonException, IOException, InterruptedException {
@@ -89,6 +99,9 @@ class MatrixHttpClientTest {
     MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString(), any()))
                       .thenReturn(responseOK);
     MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString())).thenReturn(responseOK);
+
+    responseNotOK = mock(HttpResponse.class);
+    when(responseNotOK.statusCode()).thenReturn(500);
 
   }
 
@@ -227,6 +240,27 @@ class MatrixHttpClientTest {
 
   @Test
   void saveUserAccount() {
+    Identity identity = new Identity();
+    identity.setRemoteId("userOne");
+    Profile profile = new Profile();
+    profile.setProperty(Profile.FULL_NAME, "User One");
+    profile.setProperty(Profile.EMAIL, "user@email.com");
+    identity.setProfile(profile);
+    String userIdOnMatrix = "userOneOnMatrix";
+
+    when(responseOK.body()).thenReturn("{\"name\": \"@userOneOnMatrix:matrix.meeds.tn\",\"access_token\":\"accessTokenForUserOne\"}");
+    String returnedUserId = matrixHttpClient.saveUserAccount(identity, userIdOnMatrix, true, accessToken);
+    assertNotNull(returnedUserId);
+    assertEquals(userIdOnMatrix, returnedUserId);
+
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userIdOnMatrix, false, accessToken, true, true);
+    assertNotNull(returnedUserId);
+    assertEquals(userIdOnMatrix, returnedUserId);
+
+
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userIdOnMatrix, false, accessToken, true, false);
+    assertNotNull(returnedUserId);
+    assertEquals(userIdOnMatrix, returnedUserId);
   }
 
   @Test
@@ -247,6 +281,37 @@ class MatrixHttpClientTest {
 
   @Test
   void joinUserToRoom() {
+    String matrixUserId = "userIdOnMatrix";
+    String roomId = "matrixRoomId";
+    boolean result = matrixHttpClient.joinUserToRoom(roomId, matrixUserId, accessToken);
+    assertTrue(result);
+
+    // Error HTTP 429 : too many requests
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString()))
+            .thenReturn(responseTooManyRequests, responseOK);
+    try {
+      result = matrixHttpClient.joinUserToRoom(roomId, matrixUserId, accessToken);
+
+      assertTrue(result);
+      verify(responseTooManyRequests, times(1)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
+    // Error HTTP 500
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString()))
+            .thenReturn(responseNotOK);
+    try {
+      result = matrixHttpClient.joinUserToRoom(roomId, matrixUserId, accessToken);
+
+      assertFalse(result);
+      verify(responseNotOK, times(1)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
   }
 
   @Test
@@ -258,7 +323,44 @@ class MatrixHttpClientTest {
   }
 
   @Test
-  void updateRoomSettings() {
+  void updateRoomSettings() throws JsonException, IOException, InterruptedException {
+    String roomId = "matrixRoomId";
+    MatrixRoomPermissions matrixRoomPermissions = new MatrixRoomPermissions();
+    MatrixUserPermission userPermission = new MatrixUserPermission();
+    userPermission.setUserName("userOne");
+    userPermission.setUserRole(SIMPLE_USER_ROLE);
+    matrixRoomPermissions.setUsers(List.of(userPermission));
+    Events events = new Events("roomName", "50", "50", "50", "50", "50", "50", "50");
+    matrixRoomPermissions.setEvents(events);
+
+    when(responseOK.body()).thenReturn("{\"event_id\": \"thisIsAnEventId\"}");
+    String result = matrixHttpClient.updateRoomSettings(roomId, matrixRoomPermissions, accessToken);
+    assertNotNull(result);
+    assertEquals("thisIsAnEventId", result);
+
+    // Error HTTP 429 : too many requests
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString()))
+            .thenReturn(responseTooManyRequests, responseOK);
+    try {
+      result = matrixHttpClient.updateRoomSettings(roomId, matrixRoomPermissions, accessToken);
+
+      assertNotNull(result);
+      verify(responseTooManyRequests, times(1)).body();
+      verify(responseOK, times(2)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
+
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString())).thenReturn(responseNotOK);
+    try {
+      matrixHttpClient.updateRoomSettings(roomId, matrixRoomPermissions, accessToken);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
   }
 
   @Test
@@ -267,10 +369,58 @@ class MatrixHttpClientTest {
 
   @Test
   void updateRoomAvatar() {
+    String roomId = "matrixRoomId";
+    String avatarUrl = "/path/to/avatar/url";
+    boolean result = matrixHttpClient.updateRoomAvatar(roomId, avatarUrl, accessToken);
+    assertTrue(result);
+
+    // Error HTTP 429 : too many requests
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString()))
+            .thenReturn(responseTooManyRequests, responseOK);
+    try {
+      result = matrixHttpClient.updateRoomAvatar(roomId, avatarUrl, accessToken);
+
+      assertTrue(result);
+      verify(responseTooManyRequests, times(1)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString())).thenReturn(responseNotOK);
+    try {
+      matrixHttpClient.updateRoomAvatar(roomId, avatarUrl, accessToken);
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+    
   }
 
   @Test
   void updateUserAvatar() {
+    String userId = "matrixIdOfUserOne";
+    String avatarUrl = "/path/to/avatar/url";
+    boolean result = matrixHttpClient.updateUserAvatar(userId, avatarUrl, accessToken);
+    assertTrue(result);
+
+    // Error HTTP 429 : too many requests
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString()))
+            .thenReturn(responseTooManyRequests, responseOK);
+    try {
+      result = matrixHttpClient.updateUserAvatar(userId, avatarUrl, accessToken);
+      assertTrue(result);
+      verify(responseTooManyRequests, times(1)).body();
+
+    } catch (Exception e) {
+      fail();
+    }
+
+    MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPutRequest(anyString(), anyString(), anyString())).thenReturn(responseNotOK);
+    result = matrixHttpClient.updateUserAvatar(userId, avatarUrl, accessToken);
+    assertFalse(result);
   }
 
   @Test
@@ -322,4 +472,40 @@ class MatrixHttpClientTest {
       fail();
     }
   }
+
+    @Test
+    void overrideRateLimitForUser() {
+      try {
+        matrixHttpClient.overrideRateLimitForUser("user", 0, 0, accessToken);
+      } catch (Exception e) {
+        fail();
+      }
+      verify(responseOK, times(1)).body();
+
+      MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpPostRequest(anyString(), anyString(), anyString())).thenReturn(responseNotOK);
+      try {
+        matrixHttpClient.overrideRateLimitForUser("user", 0, 0, accessToken);
+        fail();
+      } catch (Exception e) {
+        // Expected
+      }
+    }
+
+    @Test
+    void getOverriddenRateLimitForUser() {
+      try {
+        matrixHttpClient.getOverriddenRateLimitForUser("user", accessToken);
+      } catch (Exception e) {
+        fail();
+      }
+      verify(responseOK, times(1)).body();
+      
+      MATRIX_HTTP_HELPER.when(() -> HTTPHelper.sendHttpGetRequest(anyString(), anyString())).thenReturn(responseNotOK);
+      try {
+        matrixHttpClient.getOverriddenRateLimitForUser("user", accessToken);
+        fail();
+      } catch (Exception e) {
+        // Expected
+      }
+    }
 }

--- a/webapp/src/main/resources/locale/portlet/matrix_en.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_en.properties
@@ -41,3 +41,15 @@ matrix.chat.label.confirmDeleteMessage=You are deleting this message. Are you su
 matrix.chat.label.confirm=Delete
 matrix.chat.label.cancel=Cancel
 matrix.chat.delete.message.success=Message deleted successfully
+matrix.chat.label.and=and
+
+matrix.chat.spaceSettings.title=Chat
+matrix.chat.spaceSettings.description=Enable space chat
+matrix.chat.spaceSettings.switch.label.enable=Enable the space chat room for this space
+matrix.chat.spaceSettings.switch.label.disable=Disable the space chat room for this space
+matrix.chat.enable.success=Chat is enabled successfully
+matrix.chat.disable.success=Chat is disabled successfully
+matrix.chat.enable.error=An error occurred when trying to enable the chat : {0}
+matrix.chat.disable.error=An error occurred when trying to disable the chat : {0}
+matrix.chat.enable.inprogress=The operation of disabling the chat is still in progress, check the chat status in few minutes
+matrix.chat.disable.inprogress=The operation of enabling the chat is still in progress, check the chat status in few minutes

--- a/webapp/src/main/resources/locale/portlet/matrix_fr.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_fr.properties
@@ -41,3 +41,15 @@ matrix.chat.label.confirmDeleteMessage=Vous allez supprimer ce message. \u00cate
 matrix.chat.label.confirm=Supprimer
 matrix.chat.label.cancel=Annuler
 matrix.chat.delete.message.success=Message supprim\u00E9 avec succ\u00e8s
+matrix.chat.label.and=et
+
+matrix.chat.spaceSettings.title=Chat
+matrix.chat.spaceSettings.description=Activer ou d\u00E9sactiver le chat dans l'espace
+matrix.chat.spaceSettings.switch.label.enable=Activer le chat dans cet espace
+matrix.chat.spaceSettings.switch.label.disable=D\u00E9sactiver le chat dans cet espace
+matrix.chat.enable.success=Le chat est activ\u00E9 avec succ\u00e8s
+matrix.chat.disable.success=Le chat est d\u00E9sactiv\u00E9 avec succ\u00e8s
+matrix.chat.enable.error=Erreur lors de l'op\u00E9ration d'activation du chat : {0}
+matrix.chat.disable.error=Erreur lors de l'op\u00E9ration de d\u00E9sactivation du chat : {0}
+matrix.chat.enable.inprogress=L'op\u00E9ration de d\u00E9sactivation du chat est encore en progr\u00e8s, veuillez v\u00E9rifier son \u00E9tat dans quelques minutes.
+matrix.chat.disable.inprogress=L'op\u00E9ration d'activation' du chat est encore en progr\u00e8s, veuillez v\u00E9rifier son \u00E9tat dans quelques minutes.

--- a/webapp/src/main/webapp/vue-apps/matrix/components/PopoverChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/PopoverChatButton.vue
@@ -1,11 +1,15 @@
 <template>    
-  <v-tooltip bottom>
+  <v-tooltip
+    v-if="displayed"
+    bottom>
     <template #activator="{ on, attrs }">
       <div
         v-bind="attrs"
         v-on="on">
         <v-btn
           :ripple="false"
+          :id="`chat${identityType}${identityId}`"
+          :key="`chat${identityType}${identityId}`"
           icon
           @click="openChatDrawer($event)">
           <v-icon size="18">fas fa-comments</v-icon>
@@ -30,24 +34,24 @@ export default {
     }
   },
   data: () => ({
-    contactMatrixId: String,
-    matrixDMRoom: String
+    displayed: false,
   }),
   created() {
+    return this.$matrixService.getSpaceRoom(this.identityId).then(room => {
+      this.displayed = room.status === 'ENABLED';
+    });
   },
   methods: {
     openChatDrawer(event) {
       event.preventDefault();
       event.stopPropagation();
-      const matrixRoom = '';
-      const currentUserMatrixId = localStorage.getItem("matrix_user_id");
       if(this.identityType === 'USER_TIPTIP') {
         this.$userService.getUser(this.identityId, 'settings').then(data => {
           const matrixIdProperty = data.properties.filter(p => p.propertyName == 'matrixId').shift();
           if(matrixIdProperty) {
-            this.contactMatrixId = matrixIdProperty.value;
-            if(this.contactMatrixId) {
-              this.$matrixService.openDMRoom(eXo.env.portal.userName, data.userName, matrixServerName, matrixUserId, this.contactMatrixId);
+            const contactMatrixId = matrixIdProperty.value;
+            if(contactMatrixId) {
+              this.$matrixService.openDMRoom(eXo.env.portal.userName, data.userName, matrixServerName, matrixUserId, contactMatrixId);
             }
           }
         });

--- a/webapp/src/main/webapp/vue-apps/matrix/components/space-settings/SpaceSettingsAdministration.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/space-settings/SpaceSettingsAdministration.vue
@@ -1,0 +1,135 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-app>
+    <template>
+      <v-card
+        id="chatSpaceSetting"
+        class="card-border-radius"
+        flat
+        v-if="displayed">
+        <v-list class="pa-0">
+          <v-list-item class="pa-0">
+            <v-list-item-content>
+              <v-list-item-title class="text-title">
+                {{ $t('matrix.chat.spaceSettings.title') }}
+              </v-list-item-title>
+              <v-list-item-title class="pt-2">
+                {{ $t('matrix.chat.spaceSettings.title') }}
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                {{ $t('matrix.chat.spaceSettings.description') }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+            <v-list-item-action>
+              <v-switch
+                v-show="!displayLoading"
+                v-model="spaceChatEnabled"
+                @change="enableOrDisableChat(!spaceChatEnabled)"
+                class="pt-5"
+                :title="this.$t(`matrix.chat.spaceSettings.switch.label.${this.switchAriaLabel}`)"
+                :aria-label="this.$t(`matrix.chat.spaceSettings.switch.label.${this.switchAriaLabel}`)" />
+              <v-progress-circular
+                v-show="displayLoading"
+                color="primary"
+                size="32"
+                indeterminate
+                class="my-auto" />
+            </v-list-item-action>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </template>
+  </v-app>
+</template>
+<script>
+export default {
+  props: {
+    spaceId: {
+      type: Object,
+      default: {},
+    }
+  },
+  data: () => ({
+    spaceChatStatus: 'ENABLED',
+    displayed: true,
+    progress: true,
+    updateInterval: 0,
+  }),
+  created() {
+    //check if space's chat is enabled
+    this.$matrixService.getSpaceRoom(this.spaceId).then(room => {
+      this.spaceChatStatus = room.status;
+      if(room.status === 'ENABLED' || room.status === 'DISABLED') {
+        this.progress = false;
+      } else {
+        this.progress = true;
+        this.startCheckingStatus();
+      }
+    });
+
+    document.addEventListener('hideSettingsApps', (event) => {
+      if (event?.detail && this.id !== event.detail) {
+        this.displayed = false;
+      }
+    });
+    document.addEventListener('showSettingsApps', () => this.displayed = true);
+  },
+  computed: {
+    switchAriaLabel() {
+      return this.spaceChatStatus === 'ENABLED' && 'disable' || 'enable';
+    },
+    spaceChatEnabled() {
+      return this.spaceChatStatus !== 'DISABLED';
+    },
+    roomEnabled() {
+      return this.spaceChatStatus === 'ENABLED';
+    },
+    roomDisabled() {
+      return this.spaceChatStatus === 'DISABLED';
+    },
+    displayLoading() {
+      return this.progress || this.spaceChatStatus === 'DISABLE_IN_PROGRESS' || this.spaceChatStatus === 'ENABLE_IN_PROGRESS';
+    }
+  },
+  methods: {
+    enableOrDisableChat(status) {
+      this.progress = true;
+      this.$matrixService.enableOrDisableChat(this.spaceId, status).then(() => {
+        this.startCheckingStatus();
+      }).catch(e => {
+        this.$root.$emit('alert-message', this.$t(`matrix.chat.${status}.error`, {0: e}), 'error');
+        this.progress = false;
+      });
+    },
+    startCheckingStatus() {
+      this.updateInterval = setInterval(() => {
+       this.$matrixService.getSpaceRoom(this.spaceId).then(room => {
+         this.spaceChatStatus = room.status;
+         if(room.status === 'ENABLED' || room.status === 'DISABLED') {
+           this.progress = false;
+           this.$root.$emit('alert-message', this.$t(`matrix.chat.${room.status === 'ENABLED' && 'enable' || 'disable'}.success`), 'success');
+           clearInterval(this.updateInterval);
+         }
+       });
+     }, 3000);
+    }
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/matrix/extension.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/extension.js
@@ -1,7 +1,5 @@
 import * as matrixService from './js/MatrixService.js';
 
-export const roomActionComponents = extensionRegistry ? extensionRegistry.loadExtensions('chat', 'chat-drawer-title-action-component') : [];
-
 export function registerChatExtensions(chatTitle) {
   const profileExtensionAction = {
     id: 'profile-matrix-chat',
@@ -10,14 +8,15 @@ export function registerChatExtensions(chatTitle) {
     class: 'fas fa-comments',
     iconOnly: true,
     order: 10,
-    enabled: (identity) => {
+    enabled: async function(identity) {
       if(identity.userName || identity.username) {
         const userMatrixId = identity.properties?.some(property => property.propertyName === 'matrixId') && identity.properties?.find(property => property.propertyName === 'matrixId').value;
         return identity?.enabled && identity.username !== eXo.env.portal.userName
                && localStorage.getItem("matrix_user_id")
                && userMatrixId;
       } else {
-        return true;
+        const room = await matrixService.getSpaceRoom(identity.id);
+        return room.status === 'ENABLED';
       }
     },
     click: (profile) => {
@@ -36,19 +35,29 @@ export function registerChatExtensions(chatTitle) {
 
   if (extensionRegistry) {
     extensionRegistry.registerExtension('profile-extension', 'action', profileExtensionAction);
+
+    extensionRegistry.registerComponent('SpaceSettings', 'space-settings-components', {
+      id: 'meeds-chat-space-settings',
+      vueComponent: Vue.options.components['meeds-chat-space-settings'],
+      rank: 10,
+    });
+
+    document.dispatchEvent(new CustomEvent('profile-extension-updated', { detail: profileExtensionAction}));
+
+    extensionRegistry.registerComponent('SpacePopover', 'space-popover-action', {
+      id: 'matrix-chat-space-popover',
+      isEnabled: async function (params) {
+        const room = await matrixService.getSpaceRoom(params.identityId);
+        return room.status === 'ENABLED';
+      },
+      vueComponent: Vue.options.components['meeds-popover-chat-button'],
+      rank: 40,
+    });
+
+    extensionRegistry.registerComponent('UserPopover', 'user-popover-action', {
+      id: 'matrix-chat-user-popover',
+      vueComponent: Vue.options.components['meeds-popover-chat-button'],
+      rank: 40,
+    });
   }
-
-  document.dispatchEvent(new CustomEvent('profile-extension-updated', { detail: profileExtensionAction}));
-
-  extensionRegistry.registerComponent('SpacePopover', 'space-popover-action', {
-    id: 'matrix-chat',
-    vueComponent: Vue.options.components['meeds-popover-chat-button'],
-    rank: 40,
-  });
-
-  extensionRegistry.registerComponent('UserPopover', 'user-popover-action', {
-    id: 'matrix-chat',
-    vueComponent: Vue.options.components['meeds-popover-chat-button'],
-    rank: 40,
-  });
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -22,7 +22,7 @@ export function checkAuthenticationTypes() {
   return fetch('/_matrix/client/r0/login', {
     method: 'GET',
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -50,7 +50,7 @@ export function authenticate() {
         'token': JWT
       })
     }).then(resp => {
-      if (!resp || !resp.ok) {
+      if (!resp?.ok) {
         throw new Error('Response code indicates a server error', resp);
       } else {
         return resp.json();
@@ -79,7 +79,7 @@ export function loadChatRooms(currentMemberId) {
                     }
                   };
   return sync(filter).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -102,7 +102,7 @@ export function processRooms(rooms) {
     },
   body: JSON.stringify(rooms)
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Could not process rooms : Response code indicates a server error', resp);
     }
     return resp.json();
@@ -118,7 +118,7 @@ export function loadRoom(roomId) {
       'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
     }
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -151,7 +151,7 @@ export function createMatrixDMRoom(matrixIdUserTwo, serverName) {
       },
       body: JSON.stringify(payLoad),
     }).then(resp => {
-      if (!resp || !resp.ok) {
+      if (!resp?.ok) {
         throw new Error('Response code indicates a server error', resp);
       } else {
         return resp.json();
@@ -163,7 +163,7 @@ export function getDMRoomsAccountData(userName) {
   return fetch(`/matrix/rest/matrix/dmRooms?user=${userName}`, {
       method: 'GET',
     }).then(resp => {
-      if (!resp || !resp.ok) {
+      if (!resp?.ok) {
         throw new Error('Response code indicates a server error', resp);
       } else {
         return resp.json();
@@ -180,7 +180,7 @@ export function updateDMRoomsAccountData(matrixIDUser, matrixUserDMRooms) {
       },
       body: JSON.stringify(matrixUserDMRooms)
     }).then(resp => {
-      if (!resp || !resp.ok) {
+      if (!resp?.ok) {
         throw new Error('Response code indicates a server error', resp);
       } else {
         return true;
@@ -431,7 +431,7 @@ export function getSpaceRoom(spaceId) {
   return fetch(`/matrix/rest/matrix/spaceRoom?spaceId=${spaceId}`, {
     method: 'GET',
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Get room by space : Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -443,7 +443,7 @@ export function getDMRoom(firstParticipant, secondParticipant, serverName, first
   return fetch(`/matrix/rest/matrix/dmRoom?firstParticipant=${firstParticipant}&secondParticipant=${secondParticipant}`, {
     method: 'GET',
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       if (resp.status === 404) {
         return createMatrixDMRoom(secondUserMatrixId || secondParticipant, serverName).then(data => {
           const payload = {
@@ -460,7 +460,7 @@ export function getDMRoom(firstParticipant, secondParticipant, serverName, first
             },
             body: JSON.stringify(payload)
             }).then(createdRoom => {
-              if (!createdRoom || !createdRoom.ok) {
+              if (!createdRoom?.ok) {
                 throw new Error('Response code indicates a server error', resp);
               } else {
                 return getDMRoomsAccountData(firstParticipant).then(accountData =>
@@ -502,7 +502,7 @@ export function getRoomById(roomId) {
      method: 'GET',
      credentials: 'include',
    }).then(resp => {
-     if (!resp || !resp.ok) {
+     if (!resp?.ok) {
        throw new Error('Get Room by Room Id : Response code indicates a server error or space not found', resp);
      } else {
        return resp.json();
@@ -570,7 +570,7 @@ export function saveFilter() {
     },
     body: JSON.stringify(payload)
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Save Filter : Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -601,7 +601,7 @@ export function savePushGateway(kind, pushKey) {
     },
     body: JSON.stringify(payload)
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Save Push gateway : Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -616,7 +616,7 @@ export function getPushers() {
      'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
     },
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Get Push gateway : Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -653,7 +653,7 @@ export function getByRoomId(roomId) {
       method: 'GET',
       credentials: 'include',
     }).then(resp => {
-      if (!resp || !resp.ok) {
+      if (!resp?.ok) {
         throw new Error('Get Space by Room Id : Response code indicates a server error or space not found', resp);
       } else {
         return resp.json();
@@ -668,7 +668,7 @@ export function getUserPresence(userIdOnMatrix) {
         'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
       }
     },).then(resp => {
-      if (!resp || !resp.ok) {
+      if (!resp?.ok) {
         throw new Error('Get User Presence on Matrix : Response code indicates a server error', resp);
       } else {
         return resp.json();
@@ -727,7 +727,7 @@ export async function loadRoomMessages(roomId, from, to) {
       'Authorization' : `Bearer ${localStorage.getItem('matrix_access_token')}`,
     },
   }).then(resp => {
-    if (!resp || !resp.ok) {
+    if (!resp?.ok) {
       throw new Error('Load room messages : Response code indicates a server error', resp);
     } else {
       return resp.json();
@@ -1389,4 +1389,24 @@ function getFormattedMessageBody(targetMessage) {
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function enableOrDisableChat(spaceId, enable) {
+  if(!spaceId) {
+    console.warn('the space Id parameter should not be null');
+    return;
+  }
+  let statusChange = enable && 'enable' || 'disable';
+  return fetch(`/matrix/rest/matrix/${statusChange}/${spaceId}`, {
+    method: 'PUT',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp?.ok) {
+      if(resp.status === 504) {
+        throw new Error('Timeout : operation is still in progress');
+      } else {
+        throw new Error(`Error while ${enable ? 'enabling' : 'disabling'} the chat on this space : response status = ${resp.status}`);
+      }
+    }
+  });
 }

--- a/webapp/src/main/webapp/vue-apps/matrix/main.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/main.js
@@ -17,6 +17,7 @@ import MessageActionList from './components/message/action/MessageActionList.vue
 import MessageReactionItem from './components/message/MessageReactionItem.vue';
 import MessageSenderName from './components/message/MessageSenderName.vue';
 import RoomLastMessage from './components/room/RoomLastMessage.vue';
+import SpaceSettingsAdministration from './components/space-settings/SpaceSettingsAdministration.vue';
 
 import * as matrixService from './js/MatrixService.js';
 import {registerChatExtensions} from './extension.js';
@@ -44,7 +45,8 @@ const components = {
   'message-action-list': MessageActionList,
   'message-reaction-item': MessageReactionItem,
   'message-sender-name': MessageSenderName,
-  'room-last-message': RoomLastMessage
+  'room-last-message': RoomLastMessage,
+  'meeds-chat-space-settings': SpaceSettingsAdministration,
 };
 
 for (const key in components) {


### PR DESCRIPTION
The fix allows enabling / disabling chat in spaces by
 - Removing all users from the chat room when the chat is disabled
 - Reinviting all users when the chat is enabled
 - Add a new column for the status for enabled room, disabled room and enabling or disabling a room in progress
 - Make the Disable/Enable call asynchronous
 - Add a loader to hide the enable/disable button Besides, in this commit , we removed the rate limits for the administrator account to avoid latency when the inviting/excluding users
