### PR TITLE
fix: remove mark as read action - MEED-9528 - Meeds-io/MIPs#189

### DIFF
--- a/webapp/src/main/webapp/js/service-worker-extension.js
+++ b/webapp/src/main/webapp/js/service-worker-extension.js
@@ -33,6 +33,7 @@ self.addEventListener('push', event => {
                 const title = chatNotification.title;
                 chatNotification.icon = self.location.origin + chatNotification.icon;
                 chatNotification.type = CHAT_NOTIFICATION_TYPE;
+                delete chatNotification.actions;
                 chatNotification = prepareNotificationToSend(eventId, chatNotification);
                 await self.registration.showNotification(title, chatNotification);
                 await refreshBadge();


### PR DESCRIPTION
Remove the default action mark as read from Chat notification