### PR TITLE
fix: do not display notification when message is already read - MEED-9558 - Meeds-io/MIPs#189

### DIFF
--- a/services/src/main/java/io/meeds/chat/model/MatrixMessage.java
+++ b/services/src/main/java/io/meeds/chat/model/MatrixMessage.java
@@ -18,6 +18,7 @@
  */
 
 package io.meeds.chat.model;
+
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  *
@@ -59,4 +60,6 @@ public class MatrixMessage {
   private String       sender;
 
   private List<String> mentionedUsers;
+
+  private long         timeStamp;
 }

--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -99,7 +99,7 @@ public class MatrixRest implements ResourceContainer {
 
   @Autowired
   private ChatNotificationService      chatNotificationService;
-  
+
   @GetMapping
   @Secured("users")
   @Operation(summary = "Get the matrix room bound to the current space", method = "GET", description = "Get the id of the matrix room bound to the current space")
@@ -185,8 +185,9 @@ public class MatrixRest implements ResourceContainer {
   }
 
   /**
-   * This API is used by Matrix server to notify the Meeds server that a user has a new notification
-   * This API is used as a Push Gateway for Matrix server
+   * This API is used by Matrix server to notify the Meeds server that a user has
+   * a new notification This API is used as a Push Gateway for Matrix server
+   * 
    * @param notification
    * @return
    */
@@ -558,7 +559,7 @@ public class MatrixRest implements ResourceContainer {
     return ResponseEntity.ok().build();
   }
 
-  @PutMapping("notification/{roomId}/{eventId}")
+  @PutMapping("notification/{roomId}/{eventId}/{ts}")
   @Secured("users")
   @Operation(summary = "Get the details of a notification based on the event details", method = "GET", description = "Get the details of a notification based on the event details")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
@@ -566,26 +567,30 @@ public class MatrixRest implements ResourceContainer {
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public PwaNotificationMessage getNotification(HttpServletRequest request, @PathVariable("roomId")
   String roomId, @PathVariable("eventId")
-  String eventId,
+  String eventId, @PathVariable("ts")
+  String timeStamp,
                                                 @RequestBody(description = "Access token of the user", required = false)
                                                 @org.springframework.web.bind.annotation.RequestBody(required = false)
                                                 String accessToken) {
+    String currentUserName = request.getRemoteUser();
+    if (eventId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "event id is mandatory");
+    }
+    long ts = 0L;
     try {
-      String currentUserName = request.getRemoteUser();
-      ChatNotificationService chatNotificationService = CommonsUtils.getService(ChatNotificationService.class);
-      if (eventId == null) {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "event id is mandatory");
-      }
-      PwaNotificationMessage pwaMessage =
-                                        chatNotificationService.createNotification(eventId, roomId, currentUserName, accessToken);
-      if (pwaMessage != null) {
-        return pwaMessage;
-      } else {
-        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found or it is not a chat message");
-      }
-    } catch (Exception e) {
-      LOG.error("Could not get details of the event: {}", eventId, e);
-      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+      ts = Long.parseLong(timeStamp);
+    } catch (NumberFormatException nfe) {
+      // Do nothing, we consider Timestamp as 0 //NOSONAR
+    }
+    PwaNotificationMessage pwaMessage = chatNotificationService.createNotification(eventId,
+                                                                                   roomId,
+                                                                                   currentUserName,
+                                                                                   ts,
+                                                                                   accessToken);
+    if (pwaMessage != null) {
+      return pwaMessage;
+    } else {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found or it is not a chat message");
     }
   }
 
@@ -612,8 +617,7 @@ public class MatrixRest implements ResourceContainer {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to mute room");
     }
   }
-  
-  
+
   private String checkAndParseUserFromToken(String token) {
     byte[] secret = PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes();
     Jws<Claims> jws = Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(secret)).build().parseClaimsJws(token);

--- a/services/src/main/java/io/meeds/chat/service/ChatNotificationService.java
+++ b/services/src/main/java/io/meeds/chat/service/ChatNotificationService.java
@@ -181,8 +181,12 @@ public class ChatNotificationService {
    * @param userName the user who received the notification
    * @return notification object
    */
-  public PwaNotificationMessage createNotification(String eventId, String roomId, String userName, String token) {
+  public PwaNotificationMessage createNotification(String eventId, String roomId, String userName, long lastMessageTimeStamp, String token) {
     MatrixMessage message = matrixService.getRoomEvent(eventId, roomId, token);
+    // Do not create a notification is the message is before the last message
+    if (lastMessageTimeStamp >= message.getTimeStamp()) {
+      return null;
+    }
     return createNotification(message, userName);
   }
 

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -1149,6 +1149,7 @@ public class MatrixHttpClient {
       message.setRoomId(jsonMessage.getElement("room_id").getStringValue());
       message.setType(jsonMessage.getElement("type").getStringValue());
       message.setSender(jsonMessage.getElement("sender").getStringValue());
+      message.setTimeStamp(Long.parseLong(jsonMessage.getElement("origin_server_ts").getStringValue()));
       if (jsonMessage.getElement("content") != null) {
         JsonValue content = jsonMessage.getElement("content");
         message.setMessageContent(content.getElement("body").getStringValue());

--- a/services/src/test/java/io/meeds/chat/service/ChatNotificationServiceTest.java
+++ b/services/src/test/java/io/meeds/chat/service/ChatNotificationServiceTest.java
@@ -120,7 +120,8 @@ class ChatNotificationServiceTest extends MatrixBaseTest {
                                                     "Message content",
                                                     "m.text",
                                                     "@sender:matrix.meeds.tn",
-                                                    Collections.singletonList("@demo:matrix.meeds.tn"));
+                                                    Collections.singletonList("@demo:matrix.meeds.tn"),
+                                                    123456789);
     when(matrixHttpClient.getEventById(eventId, roomId, accessToken)).thenReturn(matrixMessage);
 
     action = chatNotificationService.sendCreateNotificationAction(eventId, "demo", roomId, 5);
@@ -154,7 +155,8 @@ class ChatNotificationServiceTest extends MatrixBaseTest {
                                                     "This is a chat message",
                                                     "m.text",
                                                     userIdOnMatrix,
-                                                    new ArrayList<>());
+                                                    new ArrayList<>(),
+                                                    123456789);
     when(matrixHttpClient.getEventById(eventId, matrixRoomId, accessToken)).thenReturn(matrixMessage);
     LocaleConfig localeConfig = new LocaleConfigImpl();
     localeConfig.setLocale(Locale.ENGLISH);
@@ -162,6 +164,7 @@ class ChatNotificationServiceTest extends MatrixBaseTest {
     PwaNotificationMessage pwaNotificationMessage = chatNotificationService.createNotification(eventId,
                                                                                                matrixRoomId,
                                                                                                userName,
+                                                                                               0,
                                                                                                accessToken);
     assertNotNull(pwaNotificationMessage);
     assertEquals("Demo exo in my space 1", pwaNotificationMessage.getTitle());
@@ -179,10 +182,15 @@ class ChatNotificationServiceTest extends MatrixBaseTest {
                                       "This is a private chat message",
                                       "m.text",
                                       userIdOnMatrix,
-                                      new ArrayList<>());
+                                      new ArrayList<>(),
+                                      123456789);
     when(matrixHttpClient.getEventById(eventId, oneToOneRoom.getRoomId(), accessToken)).thenReturn(matrixMessage);
 
-    pwaNotificationMessage = chatNotificationService.createNotification(eventId, oneToOneRoom.getRoomId(), userName, accessToken);
+    pwaNotificationMessage = chatNotificationService.createNotification(eventId,
+                                                                        oneToOneRoom.getRoomId(),
+                                                                        userName,
+                                                                        0,
+                                                                        accessToken);
     assertNotNull(pwaNotificationMessage);
     assertNotNull(pwaNotificationMessage.getIcon());
     assertEquals(tomIdentity.getProfile().getFullName(), pwaNotificationMessage.getTitle());
@@ -254,7 +262,8 @@ class ChatNotificationServiceTest extends MatrixBaseTest {
                                                     "This is a chat message",
                                                     "m.text",
                                                     userIdOnMatrix,
-                                                    Collections.singletonList("@demo:matrix.meeds.tn"));
+                                                    Collections.singletonList("@demo:matrix.meeds.tn"),
+                                                    123456789);
     when(matrixHttpClient.getEventById(eventId, matrixRoomId, accessToken)).thenReturn(matrixMessage);
 
     boolean result = chatNotificationService.createMentionNotification(eventId, "fakeRoomId", "demo", null);

--- a/webapp/src/main/webapp/js/service-worker-extension.js
+++ b/webapp/src/main/webapp/js/service-worker-extension.js
@@ -1,5 +1,15 @@
 let accessToken = null;
+let userId = null;
 const CHAT_NOTIFICATION_TYPE = 'CHAT_NOTIFICATION';
+const DB_SETTINGS = {
+  DB_NAME: 'CHAT',
+  DB_VERSION: 4,
+  DB_STORES: {
+    SETTINGS: 'SETTINGS',
+    READ_RECEIPTS: 'READ_RECEIPTS',
+  }
+};
+
 self.addEventListener('push', event => {
   if (self?.Notification?.permission === 'granted') {
     const data = event?.data?.text?.() || {};
@@ -15,9 +25,13 @@ self.addEventListener('push', event => {
           try {
             if (action === 'open') {
               if (!accessToken) {
-                accessToken = await retrieveAccessToken();
+                const userSettings = await retrieveUserSettings();
+                accessToken = userSettings.access_token;
+                userId = userSettings.user_id;
               }
-              let chatNotification = await fetch(`/matrix/rest/matrix/notification/${roomId}/${eventId}`, {
+              const lastReadMessageObject = await retrieveLastReadObject(roomId);
+              const lastReadMessageTimestamp = lastReadMessageObject && lastReadMessageObject[userId] && lastReadMessageObject[userId].ts || 0;
+              let chatNotification = await fetch(`/matrix/rest/matrix/notification/${roomId}/${eventId}/${lastReadMessageTimestamp}`, {
                 method: 'PUT',
                 credentials: 'include',
                 body: accessToken
@@ -48,12 +62,17 @@ self.addEventListener('push', event => {
   }
 });
 
-async function retrieveAccessToken() {
-  const dbName ='CHAT';
-  const dbStore = 'SETTINGS';
-  const dbVersion = 3;
-  // Open indexDb
-  const request = indexedDB.open(dbName, dbVersion);
+async function retrieveUserSettings() {
+  return retrieveFromDb(DB_SETTINGS.DB_STORES.SETTINGS, 'settings');
+}
+
+async function retrieveLastReadObject(roomId) {
+  const itemKey = `lastRead::${roomId}`;
+  return retrieveFromDb(DB_SETTINGS.DB_STORES.READ_RECEIPTS, itemKey);
+}
+
+async function retrieveFromDb(dbStore, itemKey) {
+  const request = indexedDB.open(DB_SETTINGS.DB_NAME, DB_SETTINGS.DB_VERSION);
   const database = await new Promise((resolve, reject) => {
     request.onerror = reject;
     request.onsuccess = e => resolve(e.target.result);
@@ -68,7 +87,7 @@ async function retrieveAccessToken() {
   });
   return new Promise(resolve => {
     const transaction = database.transaction([dbStore], 'readonly');
-    const request = transaction.objectStore(dbStore).get('access_token');
+    const request = transaction.objectStore(dbStore).get(itemKey);
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => resolve(null);
   });

--- a/webapp/src/main/webapp/vue-apps/matrix/js/Constants.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/Constants.js
@@ -32,7 +32,7 @@ export const chatConstants = {
   // IndexedDB configuration
   DB_SETTINGS: {
     DB_NAME: 'CHAT',
-    DB_VERSION: 3,
+    DB_VERSION: 4,
     DB_STORES: {
       SETTINGS: 'SETTINGS',
       READ_RECEIPTS: 'READ_RECEIPTS',

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -350,12 +350,15 @@ async function handleReadReceiptEvent(event, roomId) {
       const readData = receipt[userId];
 
       // Only update if eventId is newer
-      const prevEventId = lastReads[userId];
+      const prevEventId = lastReads[userId].eventId;
       const prevTimestamp = prevEventId ? messageTimestampsMap.get(prevEventId) : 0;
       const newTimestamp = messageTimestampsMap.get(eventId);
 
       if (!prevEventId || (newTimestamp && newTimestamp > prevTimestamp)) {
-        lastReads[userId] = eventId;
+        lastReads[userId] = {
+          eventId: eventId,
+          ts: newTimestamp,
+        }
       }
 
       document.dispatchEvent(new CustomEvent('matrix-message-read', {
@@ -377,7 +380,7 @@ async function handleReadReceiptEvent(event, roomId) {
 
 export async function loadReadReceiptsForMessage(lastReads, eventId) {
   return Object.entries(lastReads)
-      .filter(([userId, lastReadEventId]) => userId !== matrixUserId && lastReadEventId === eventId)
+      .filter(([userId, lastReadEvent]) => userId !== matrixUserId && lastReadEvent.eventId === eventId)
       .map(([userId]) => userId);
 }
 
@@ -1028,7 +1031,7 @@ export async function getLastReadEventIds(roomId) {
   const lastReads = await loadLastReadReceipts(roomId);
   const filteredReads = Object.entries(lastReads)
       .filter(([key]) => key !== matrixUserId)
-      .map(([, value]) => value);
+      .map(([, value]) => value.eventId);
   return new Set(filteredReads);
 }
 
@@ -1494,11 +1497,15 @@ export async function registerUserToken() {
   if (!dbExists) {
     await dbStorage.createDatabase(chatConstants.DB_SETTINGS);
   }
+  const settings = {
+    'access_token': localStorage.getItem("matrix_access_token"),
+    'user_id': localStorage.getItem("matrix_user_id")
+  };
   await dbStorage.setValue(
     chatConstants.DB_SETTINGS,
     chatConstants.DB_SETTINGS.DB_STORES.SETTINGS,
-   'access_token',
-    localStorage.getItem("matrix_access_token")
+   'settings',
+    settings
   );
 }
 


### PR DESCRIPTION
Before displaying a push notification, is check is done to make sure that the message was not already viewed. In that case, the message is ignored.