### PR TITLE
fix: build failure on MatrixRest#notify unit test - MEED-9738

### DIFF
--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -219,7 +219,6 @@ public class MatrixRest implements ResourceContainer {
                 """.formatted(pushKey);
           }
           if (StringUtils.isNotBlank(userName)) {
-            ChatNotificationService chatNotificationService = CommonsUtils.getService(ChatNotificationService.class);
             int unreadCount = 0;
             JsonValue element = notifJsonValue.getElement("counts");
             if (element != null && element.getElement("unread") != null) {


### PR DESCRIPTION
Randomly, the unit test of io.meeds.chat.rest.MatrixRest#notify function fails .
This fix avoids re-importing the service **ChatNotificationService** which become null in some cases and use the inject service instance.