### PR TITLE
fix: use websockets for push notifications - MEED-9670

### DIFF
--- a/services/src/main/java/io/meeds/chat/service/ChatNotificationService.java
+++ b/services/src/main/java/io/meeds/chat/service/ChatNotificationService.java
@@ -63,6 +63,9 @@ import java.util.*;
 import static io.meeds.chat.service.utils.MatrixConstants.*;
 import static io.meeds.pwa.service.PwaNotificationService.*;
 
+/**
+ * This service creates and manages all different notifications related to the chat application
+ */
 @Service
 public class ChatNotificationService {
   private static final Log          LOG                          = ExoLogger.getLogger(ChatNotificationService.class);
@@ -113,7 +116,6 @@ public class ChatNotificationService {
    * @param userName the user name
    * @param roomId the room ID
    * @param unreadCount the number of unread messages
-   * @return thread to perform notification action
    */
   public void sendCreateNotificationAction(String eventId, String userName, String roomId, int unreadCount) {
     if (!canSendPushNotificationToUser(userName, roomId)) {
@@ -189,6 +191,8 @@ public class ChatNotificationService {
    * @param eventId the event Id
    * @param roomId the room ID
    * @param userName the user who received the notification
+   * @param lastMessageTimeStamp the timestamp of the last message
+   * @param token the authorization token
    * @return notification object
    */
   public PwaNotificationMessage createNotification(String eventId,
@@ -211,6 +215,7 @@ public class ChatNotificationService {
    * @param roomId the room ID
    * @param userName the username of the receiver of the notification
    * @param pushKey jwt token of one of the users in case the room is private
+   * @return true if the Mention notification is created, false otherwise
    */
   public boolean createMentionNotification(String eventId, String roomId, String userName, String pushKey) {
     Room room = matrixService.getById(roomId);

--- a/webapp/src/main/webapp/js/service-worker-extension.js
+++ b/webapp/src/main/webapp/js/service-worker-extension.js
@@ -38,17 +38,19 @@ self.addEventListener('push', event => {
 });
 
 self.addEventListener('message', event => {
-  if (self?.Notification?.permission === 'granted') {
-    const data = event?.data || {};
-    if(data.type === CHAT_NOTIFICATION_TYPE) {
-      if (data.roomId && data.eventId) {
-        event.waitUntil(new Promise(async (resolve, reject) => {
-          try {
-            processChatNotification(data.roomId, data.eventId);
-          } catch (e) {
-            reject(e);
-          }
-        }));
+  if (event.origin === self.location.origin) {
+    if (self?.Notification?.permission === 'granted') {
+      const data = event?.data || {};
+      if(data.type === CHAT_NOTIFICATION_TYPE) {
+        if (data.roomId && data.eventId) {
+          event.waitUntil(new Promise(async (resolve, reject) => {
+            try {
+              processChatNotification(data.roomId, data.eventId);
+            } catch (e) {
+              reject(e);
+            }
+          }));
+        }
       }
     }
   }


### PR DESCRIPTION
When the user has an active session on a device, we will use the websocket channel to send Push notifications. Otherwise we will use the Push provider for sending them.