### PR TITLE
fix: allow creating users with numeric identifiers in Matrix - MEED-9787

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This addon allows to integrate Matrix as the chat server.
 - **meeds.matrix.shared_secret_registration**: The shared registration token that will be used for creating new user accounts, it takes the value of the property **registration_shared_secret** that could be found inside the _homeserver.yaml_ configuration file of the Matrix/Synapse server
 - **meeds.matrix.user.display.name** : the display name of the user used to interact with Matrix API
 - **meeds.matrix.jwt.secret** : the secret that will be used to generate the JWT tokens sent to Matrix for authenticating users
+- **meeds.matrix.username.prefix** : This is the prefix that will be added to usernames that are composed of digits only. The default value is the letter **u**
 
 
 ## Create a user on Matrix server

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -63,6 +63,7 @@ import java.time.Instant;
 import java.util.*;
 
 import static io.meeds.chat.service.utils.MatrixConstants.*;
+import static org.apache.commons.lang3.StringUtils.isNumeric;
 
 @Service
 public class MatrixService {
@@ -348,8 +349,15 @@ public class MatrixService {
                                 boolean isNew,
                                 boolean isEnableUserOperation,
                                 boolean isUserEnabled) throws JsonException, IOException, InterruptedException {
+
+    String matrixUserId = user.getRemoteId();
+    if (isNumeric(user.getRemoteId())) {
+      String prefix = StringUtils.isNotBlank(PropertyManager.getProperty(MATRIX_USERNAME_PREFIX)) ? PropertyManager.getProperty(MATRIX_USERNAME_PREFIX) : "u";
+      matrixUserId = prefix + user.getRemoteId();
+    }
+    matrixUserId = cleanMatrixUsername(matrixUserId);
     String matrixId = matrixHttpClient.saveUserAccount(user,
-                                                       user.getRemoteId(),
+                                                       matrixUserId,
                                                        isNew,
                                                        this.getMatrixAccessToken(),
                                                        isEnableUserOperation,
@@ -789,7 +797,7 @@ public class MatrixService {
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
       return userMatrixId;
-    } catch ( Exception e) {
+    } catch (Exception e) {
       return userMatrixId;
     }
     return userMatrixId;
@@ -814,5 +822,15 @@ public class MatrixService {
     } finally {
       RequestLifeCycle.end();
     }
+  }
+
+  /**
+   * Cleans the username to be compatible with the usernames on Matrix server
+   *
+   * @param userName the user identifier
+   * @return String the cleaned username
+   */
+  public String cleanMatrixUsername(String userName) {
+    return userName.replaceAll("[^a-zA-Z0-9=_\\-\\.\\/+]+", "-").toLowerCase();
   }
 }

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixConstants.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixConstants.java
@@ -40,6 +40,8 @@ public class MatrixConstants {
 
   public static final String                   MATRIX_SERVER_NAME                          = "meeds.matrix.server.name";
 
+  public static final String                   MATRIX_USERNAME_PREFIX                      = "meeds.matrix.username.prefix";
+
   public static final String                   MATRIX_RESTRICTED_USERS_GROUP               =
                                                                              "meeds.matrix.restricted.users.groupId";
 

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import static io.meeds.chat.service.utils.HTTPHelper.*;
 import static io.meeds.chat.service.utils.MatrixConstants.*;
+import static org.apache.commons.lang3.StringUtils.isNumeric;
 
 @Component
 public class MatrixHttpClient {
@@ -230,7 +231,7 @@ public class MatrixHttpClient {
            "admin": false,
            "mac": "%s"
           }
-        """.formatted(nonce, cleanMatrixUsername(user.getUserName()), user.getDisplayName(), user.getUserName(), hmac);
+        """.formatted(nonce, user.getUserName(), user.getDisplayName(), user.getUserName(), hmac);
 
     try {
       HttpResponse<String> response = sendHttpPostRequest(url, token, payload);
@@ -333,7 +334,7 @@ public class MatrixHttpClient {
       throw new IllegalArgumentException(MATRIX_SERVER_URL_IS_REQUIRED);
     }
 
-    String fullMatrixUserId = "@%s:%s".formatted(cleanMatrixUsername(matrixUserId),
+    String fullMatrixUserId = "@%s:%s".formatted(matrixUserId,
                                                  PropertyManager.getProperty(MATRIX_SERVER_NAME));
     String url = PropertyManager.getProperty(MATRIX_SERVER_URL) + "/_synapse/admin/v2/users/" + fullMatrixUserId;
 
@@ -355,7 +356,7 @@ public class MatrixHttpClient {
             "user_type": null,
             "locked": false
           }
-          """.formatted(password, user.getRemoteId(), user.getProfile().getEmail());
+          """.formatted(password, user.getProfile().getFullName(), user.getProfile().getEmail());
     } else if (isEnableUserOperation && isUserEnabled) {
       payload = """
           {
@@ -923,16 +924,6 @@ public class MatrixHttpClient {
       LOG.error("Could not delete the room on Matrix", e);
       return false;
     }
-  }
-
-  /**
-   * Cleans the username to be compatible with the usernames on Matrix server
-   * 
-   * @param userName the user identifier
-   * @return String the cleaned username
-   */
-  public String cleanMatrixUsername(String userName) {
-    return userName.replaceAll("[^a-zA-Z0-9=_\\-\\.\\/+]+", "-").toLowerCase();
   }
 
   public String getUserDisplayName(String userMatrixId,

--- a/services/src/main/java/io/meeds/chat/web/MatrixAuthJWTFilter.java
+++ b/services/src/main/java/io/meeds/chat/web/MatrixAuthJWTFilter.java
@@ -60,13 +60,16 @@ public class MatrixAuthJWTFilter implements Filter {
       if (cookies != null) {
         if (httpRequest.getRemoteUser() != null
             && Arrays.stream(cookies).noneMatch(cookie -> MATRIX_JWT_COOKIE.equals(cookie.getName()))) {
-          String sessionToken = matrixService.getJWTSessionToken(httpRequest.getRemoteUser());
-          Cookie cookie = new Cookie(MATRIX_JWT_COOKIE, sessionToken);
-          cookie.setPath("/");
-          cookie.setMaxAge(604800); // 7 days in seconds
-          cookie.setHttpOnly(false);
-          cookie.setSecure(request.isSecure());
-          httpResponse.addCookie(cookie);
+          String userNameOnMatrix = matrixService.getMatrixIdForUser(httpRequest.getRemoteUser());
+          if (StringUtils.isNotBlank(userNameOnMatrix)) {
+            String sessionToken = matrixService.getJWTSessionToken(userNameOnMatrix);
+            Cookie cookie = new Cookie(MATRIX_JWT_COOKIE, sessionToken);
+            cookie.setPath("/");
+            cookie.setMaxAge(604800); // 7 days in seconds
+            cookie.setHttpOnly(false);
+            cookie.setSecure(request.isSecure());
+            httpResponse.addCookie(cookie);
+          }
         } else if (StringUtils.isBlank(httpRequest.getRemoteUser())) {
           Cookie oldCookie = Arrays.stream(cookies)
                                    .filter(cookie -> MATRIX_JWT_COOKIE.equals(cookie.getName()))

--- a/services/src/test/java/MatrixUtilsTest.java
+++ b/services/src/test/java/MatrixUtilsTest.java
@@ -123,16 +123,6 @@ public class MatrixUtilsTest {
     }
   }
 
-  @Test
-  public void testCleanMatrixUsername() {
-    String[] usernames = new String[] { "Samueâl", "fre@d", "Shazia", "gorkef/",
-        "²&é\"'(-è_çà)=²1234567890°+'azertyuiopqsdfghjklmù*^$wxcvbn,;:!?./§%µ¨£<>²&~#{[|`\\^@]}" };
-    for (String username : usernames) {
-      String result = matrixHttpClient.cleanMatrixUsername(username);
-      assertNotNull(result);
-    }
-  }
-
   public void testDeleteSpace() throws Exception {
     long currentTime = System.currentTimeMillis();
     String matrixRoomId =

--- a/services/src/test/java/io/meeds/chat/service/MatrixServiceTest.java
+++ b/services/src/test/java/io/meeds/chat/service/MatrixServiceTest.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -291,5 +292,15 @@ class MatrixServiceTest extends MatrixBaseTest {
     when(matrixHttpClient.invalidateAccessToken(accessToken)).thenThrow(new InterruptedException());
     result = matrixService.invalidateAccessToken("sys_sampleAccessToken");
     assertFalse(result);
+  }
+
+  @org.junit.Test
+  public void testCleanMatrixUsername() {
+    String[] usernames = new String[] { "Samueâl", "fre@d", "Shazia", "gorkef/",
+            "²&é\"'(-è_çà)=²1234567890°+'azertyuiopqsdfghjklmù*^$wxcvbn,;:!?./§%µ¨£<>²&~#{[|`\\^@]}" };
+    for (String username : usernames) {
+      String result = matrixService.cleanMatrixUsername(username);
+      assertNotNull(result);
+    }
   }
 }

--- a/services/src/test/java/io/meeds/chat/service/utils/MatrixHttpClientTest.java
+++ b/services/src/test/java/io/meeds/chat/service/utils/MatrixHttpClientTest.java
@@ -263,20 +263,52 @@ class MatrixHttpClientTest {
     profile.setProperty(Profile.FULL_NAME, "User One");
     profile.setProperty(Profile.EMAIL, "user@email.com");
     identity.setProfile(profile);
-    String userIdOnMatrix = "userOneOnMatrix";
+    String userId = "userOneOnMatrix";
 
     when(responseOK.body()).thenReturn("{\"name\": \"@userOneOnMatrix:matrix.meeds.tn\",\"access_token\":\"accessTokenForUserOne\"}");
-    String returnedUserId = matrixHttpClient.saveUserAccount(identity, userIdOnMatrix, true, accessToken);
+    String returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, true, accessToken);
     assertNotNull(returnedUserId);
-    assertEquals(userIdOnMatrix, returnedUserId);
+    assertEquals(userId, returnedUserId);
 
-    returnedUserId = matrixHttpClient.saveUserAccount(identity, userIdOnMatrix, false, accessToken, true, true);
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, false, accessToken, true, true);
     assertNotNull(returnedUserId);
-    assertEquals(userIdOnMatrix, returnedUserId);
+    assertEquals(userId, returnedUserId);
 
-    returnedUserId = matrixHttpClient.saveUserAccount(identity, userIdOnMatrix, false, accessToken, true, false);
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, false, accessToken, true, false);
     assertNotNull(returnedUserId);
-    assertEquals(userIdOnMatrix, returnedUserId);
+    assertEquals(userId, returnedUserId);
+
+    // username with only digits
+    // Default prefix : u
+    userId = "12";
+    when(responseOK.body()).thenReturn("{\"name\": \"@u12:matrix.meeds.tn\",\"access_token\":\"accessTokenForU12\"}");
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, false, accessToken, true, false);
+    assertNotNull(returnedUserId);
+    assertEquals("u" + userId, returnedUserId);
+
+    // Customized prefix : user
+    userId = "12";
+    when(responseOK.body()).thenReturn("{\"name\": \"@user12:matrix.meeds.tn\",\"access_token\":\"accessTokenForUser12\"}");
+    PropertyManager.setProperty(MATRIX_USERNAME_PREFIX, "user");
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, false, accessToken, true, false);
+    assertNotNull(returnedUserId);
+    assertEquals("user" + userId, returnedUserId);
+    // Customized prefix : user
+    userId = "12";
+    when(responseOK.body()).thenReturn("{\"name\": \"@user12:matrix.meeds.tn\",\"access_token\":\"accessTokenForUser12\"}");
+    PropertyManager.setProperty(MATRIX_USERNAME_PREFIX, "user");
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, false, accessToken, true, false);
+    assertNotNull(returnedUserId);
+    assertEquals("user" + userId, returnedUserId);
+
+    // Customized prefix : user
+    userId = "12";
+    when(responseOK.body()).thenReturn("{\"name\": \"@user12:matrix.meeds.tn\",\"access_token\":\"accessTokenForUser12\"}");
+    PropertyManager.setProperty(MATRIX_USERNAME_PREFIX, "user");
+    returnedUserId = matrixHttpClient.saveUserAccount(identity, userId, false, accessToken, true, false);
+    assertNotNull(returnedUserId);
+    assertEquals("user" + userId, returnedUserId);
+
   }
 
   @Test


### PR DESCRIPTION
Matrix does not allow creating users with numeric usernames, even though Meeds allows it
To workaround that limitation, the created usernames will be prefixed by a String, by default the letter **u**
This prefix could be customized using the property **meeds.matrix.username.prefix**
