### PR TITLE
fix: improve displaying rooms on first display - MEED-9326

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
@@ -96,12 +96,12 @@
             this.$matrixService.authenticate().then(resp => {
               if(resp.user_id) {
                 this.$matrixService.initUserData(resp);
-                this.loadRooms();
                 this.$matrixService.saveFilter().then(filterResponse => {
                   this.$matrixService.startMatrixSyncLoop(filterResponse.filter_id);
                   this.bindSyncPollingListeners(filterResponse.filter_id);
                 });
                 this.$matrixService.installPusher();
+                this.$nextTick().then(() => this.loadRooms());
               } else {
                 this.$root.$emit('alert-message', `${this.$t('meeds.matrix.login.failed')}`, 'error');
                 this.$root.$emit('matrix-login-failed');
@@ -112,7 +112,7 @@
           }
         });
       } else {
-        this.loadRooms();
+        this.$nextTick().then(() => this.loadRooms());
         this.$matrixService.saveFilter().then(filterResponse => {
           this.$matrixService.startMatrixSyncLoop(filterResponse.filter_id);
           this.bindSyncPollingListeners(filterResponse.filter_id);

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
@@ -1,3 +1,19 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2025 Meeds Association contact@meeds.io
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
 <template>
   <exo-drawer
     ref="meedsChatDrawer"

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -1,3 +1,19 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2025 Meeds Association contact@meeds.io
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
 <template>
   <div
     :id="`room${room.spaceId || room.dmMemberId}`"
@@ -110,9 +126,11 @@ export default {
     }
   },
   created() {
-    if (this.room?.directChat) {
-      this.getUserStatus();
-    }
+    this.$nextTick().then(() => {
+      if (this.room?.directChat) {
+        this.getUserStatus();
+      }
+    });
   },
   computed: {
     isSelected() {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
@@ -26,7 +26,8 @@
         :selectedRoom="selectedRoom"
         :room="room" />
     </div>
-    <div id="remainingRoomsElement">
+    <div id="remainingRoomsElement"
+      v-intersect="onIntersect">
       <matrix-chat-room
         v-if="rooms?.length > limit && displayRemainingRooms"
         v-for="room in remainingRooms"
@@ -64,30 +65,12 @@
     },
     data() {
       return {
-        observer: null,
         limit: 20,
         displayRemainingRooms: false,
       }
     },
     created() {
       document.addEventListener('matrix-joined-room', this.addJoinedRoom);
-    },
-    mounted () {
-      const callback = (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            this.displayRemainingRooms = true;
-          }
-        });
-      };
-      const options = {
-        root: null,
-        rootMargin: '0px',
-        scrollMargin: '0px',
-        threshold: 0.1,
-      };
-      this.observer = new IntersectionObserver(callback, options);
-      this.observer.observe(document.getElementById('remainingRoomsElement'));
     },
     beforeDestroy() {
       document.removeEventListener('matrix-joined-room', this.addJoinedRoom);
@@ -111,6 +94,13 @@
           this.rooms[roomExistsIndex].members.unshift(event.detail.members);
         }
       },
+      onIntersect(entries) {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            this.displayRemainingRooms = true;
+          }
+        });
+      }
     }
   }
 </script>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
@@ -1,12 +1,39 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2025 Meeds Association contact@meeds.io
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+
 <template>
   <div
     v-if="rooms?.length"
     class="d-flex flex-column">
-    <matrix-chat-room
-      v-for="room in rooms"
-      :key="room.id"
-      :selectedRoom="selectedRoom"
-      :room="room" />
+    <div id="initialRoomsElement">
+      <matrix-chat-room
+        v-for="room in initialRooms"
+        :key="room.id"
+        :selectedRoom="selectedRoom"
+        :room="room" />
+    </div>
+    <div id="remainingRoomsElement">
+      <matrix-chat-room
+        v-if="rooms?.length > limit && displayRemainingRooms"
+        v-for="room in remainingRooms"
+        :key="room.id"
+        :selectedRoom="selectedRoom"
+        :room="room" />
+    </div>
   </div>
   <div v-else-if="!loading" class="d-flex full-height align-center justify-center full-width">
     <div>
@@ -35,11 +62,43 @@
         default: null
       }
     },
+    data() {
+      return {
+        observer: null,
+        limit: 20,
+        displayRemainingRooms: false,
+      }
+    },
     created() {
       document.addEventListener('matrix-joined-room', this.addJoinedRoom);
     },
+    mounted () {
+      const callback = (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            this.displayRemainingRooms = true;
+          }
+        });
+      };
+      const options = {
+        root: null,
+        rootMargin: '0px',
+        scrollMargin: '0px',
+        threshold: 0.1,
+      };
+      this.observer = new IntersectionObserver(callback, options);
+      this.observer.observe(document.getElementById('remainingRoomsElement'));
+    },
     beforeDestroy() {
       document.removeEventListener('matrix-joined-room', this.addJoinedRoom);
+    },
+    computed: {
+      initialRooms() {
+        return this.rooms.slice(0, this.limit);
+      },
+      remainingRooms() {
+        return this.rooms.slice(this.limit, this.rooms.length);
+      }
     },
     methods: {
       addJoinedRoom(event) {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomLastMessage.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomLastMessage.vue
@@ -112,7 +112,9 @@ export default{
         formattedContent = await this.formatReactionLastMessageContent(this.room.lastMessage);
       } else {
         const senderLabel = await this.resolveLastMessageSenderLabel();
-        formattedContent = this.$t('matrix.chat.lastMessage.pattern', {
+        // use this.$root.$t instead of this.$t
+        // workaround for https://github.com/intlify/vue-i18n/issues/990
+        formattedContent = this.$root.$t('matrix.chat.lastMessage.pattern', {
           0: senderLabel,
           1: content
         });
@@ -134,12 +136,12 @@ export default{
       }
 
       return isSelf
-          ? this.$t('matrix.message.you.reacted.with', {0: reactionKey, 1: content})
-          : this.$t('matrix.message.user.reacted.with', {0: reactedBy, 1: reactionKey, 2: content});
+          ? this.$root.$t('matrix.message.you.reacted.with', {0: reactionKey, 1: content})
+          : this.$root.$t('matrix.message.user.reacted.with', {0: reactedBy, 1: reactionKey, 2: content});
     },
     async resolveLastMessageSenderLabel() {
       if (this.isLastMessageSenderCurrentUser) {
-        return this.$t('matrix.words.you');
+        return this.$root.$t('matrix.words.you');
       }
 
       const user = await this.$matrixService.getUserByMatrixId(this.lastMessageSender, this.room);

--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomLastMessage.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomLastMessage.vue
@@ -48,8 +48,10 @@ export default{
     },
   },
   created() {
-    this.getAndBuildRoomLastMessage();
     document.addEventListener('matrix-message-reaction-removed', this.reactionRemoved);
+  },
+  mounted() {
+    this.$nextTick().then(() => this.getAndBuildRoomLastMessage());
   },
   computed: {
     lastMessageContent() {


### PR DESCRIPTION
To improve the rendering time for rooms inside the drawer : 

- Make the calls of loading last message and the display of the room information inside the next rendering cycle (nextTick)
- limit the number of the initial displayed room to 30
- The rest of roomw will be displayed if the user scrolls to the bottom and tries to display the rest of rooms. 