### PR TITLE
fix: remove profile property setting matrixId - MEED-9741 (#365)

### DIFF
--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -594,30 +594,6 @@ public class MatrixRest implements ResourceContainer {
     }
   }
 
-  @PostMapping("/muteRoom")
-  @Secured("users")
-  @Operation(summary = "Mute a private room for the current user", description = "Adds a private room to the user's muted list")
-  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Room muted successfully"),
-      @ApiResponse(responseCode = "400", description = "Missing or invalid parameters"),
-      @ApiResponse(responseCode = "500", description = "Internal server error") })
-  public ResponseEntity<String> muteRoom(HttpServletRequest request,
-                                         @Parameter(description = "ID of the room to mute")
-                                         @RequestParam(name = "roomId")
-                                         String roomId) {
-
-    String userName = request.getRemoteUser();
-    if (StringUtils.isBlank(roomId)) {
-      return ResponseEntity.badRequest().body("roomId parameter is required");
-    }
-    try {
-      chatNotificationService.toggleMutePrivateRoom(userName, roomId);
-      return ResponseEntity.ok("Room muted successfully");
-    } catch (Exception e) {
-      LOG.error("Error muting room {} for user {}", roomId, userName, e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to mute room");
-    }
-  }
-
   @GetMapping("/isPushNotificationsEnabled/{userName}")
   @Secured("users")
   @Operation(summary = "Get the status of push notifications enabled/disabled", method = "GET", description = "Get the status of push notifications enabled/disabled")
@@ -663,6 +639,50 @@ public class MatrixRest implements ResourceContainer {
     } catch (Exception e) {
       LOG.error("Could not update the status of Push notifications of {}", e);
       return ResponseEntity.internalServerError().build();
+    }
+  }
+
+  @PostMapping("/muteRoom")
+  @Secured("users")
+  @Operation(summary = "Mute a private room for the current user", description = "Adds a private room to the user's muted list")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Room muted successfully"),
+      @ApiResponse(responseCode = "400", description = "Missing or invalid parameters"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
+  public ResponseEntity<String> muteRoom(HttpServletRequest request,
+                                         @Parameter(description = "ID of the room to mute")
+                                         @RequestParam(name = "roomId")
+                                         String roomId) {
+
+    String userName = request.getRemoteUser();
+    if (StringUtils.isBlank(roomId)) {
+      return ResponseEntity.badRequest().body("roomId parameter is required");
+    }
+    try {
+      chatNotificationService.toggleMutePrivateRoom(userName, roomId);
+      return ResponseEntity.ok("Room muted successfully");
+    } catch (Exception e) {
+      LOG.error("Error muting room {} for user {}", roomId, userName, e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to mute room");
+    }
+  }
+  
+  
+  @GetMapping("findId/{userId}")
+  @Secured("users")
+  @Operation(summary = "Get the matrix ID of a user", method = "GET", description = "Get the matrix ID of a user")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "404", description = "User not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error") })
+  public ResponseEntity<String> getMatrixId(@PathVariable("userId")
+  String userId) {
+    if (userId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "user id is mandatory");
+    }
+    String matrixId = matrixService.getMatrixIdForUser(userId);
+    if (StringUtils.isNotBlank(matrixId)) {
+      return ResponseEntity.ok().body(matrixId);
+    } else {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "There is no Matrix account for the user " + userId);
     }
   }
 

--- a/services/src/main/java/io/meeds/chat/upgrade/RemoveProfilePropertyUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/chat/upgrade/RemoveProfilePropertyUpgradePlugin.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.chat.upgrade;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
+
+/**
+ * Upgrade plugin to remove the profile property matrixId
+ */
+public class RemoveProfilePropertyUpgradePlugin extends UpgradeProductPlugin {
+  private static final Log       LOG = ExoLogger.getExoLogger(RemoveProfilePropertyUpgradePlugin.class);
+
+  private final ProfilePropertyService profilePropertyService;
+
+  public RemoveProfilePropertyUpgradePlugin(SettingService settingService,
+                                            InitParams initParams,
+                                            ProfilePropertyService profilePropertyService) {
+    super(settingService, initParams);
+    this.profilePropertyService = profilePropertyService;
+  }
+
+  @Override
+  public void processUpgrade(String s, String s1) {
+    LOG.info("Start:: Remove the profile property MatrixId");
+    ProfilePropertySetting profilePropertySetting = this.profilePropertyService.getProfileSettingByName("matrixId");
+    if(profilePropertySetting != null) {
+      this.profilePropertyService.deleteProfilePropertySetting(profilePropertySetting.getId());
+      LOG.info("Summary :: removed successfully the profile property matrixId !");
+    }
+  }
+}

--- a/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
+++ b/services/src/test/java/io/meeds/chat/rest/MatrixRestTest.java
@@ -62,6 +62,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -103,28 +104,28 @@ class MatrixRestTest {
   @Autowired
   private WebApplicationContext        context;
 
-  @MockBean
+  @MockitoBean
   private SpaceService                 spaceService;
 
-  @MockBean
+  @MockitoBean
   private MatrixService                matrixService;
 
-  @MockBean
+  @MockitoBean
   private MatrixSynchronizationService matrixSynchronizationService;
 
-  @MockBean
+  @MockitoBean
   private IdentityManager              identityManager;
 
-  @MockBean
+  @MockitoBean
   private ResourceBundleService        resourceBundleService;
 
-  @MockBean
+  @MockitoBean
   private NotificationService          notificationService;
 
-  @MockBean
+  @MockitoBean
   private ChatNotificationService      chatNotificationService;
 
-  @MockBean
+  @MockitoBean
   PwaNotificationService               pwaNotificationService;
 
   MockedStatic<LinkProvider>           LINK_PROVIDER;
@@ -520,21 +521,6 @@ class MatrixRestTest {
   }
 
   @Test
-  void muteRoom() throws Exception {
-    String roomId = "!testRoomToMute:matrix.meeds.tn";
-    doNothing().when(chatNotificationService).toggleMutePrivateRoom(SIMPLE_USER, roomId);
-
-    ResultActions response = mockMvc.perform(post(REST_PATH + "/muteRoom").with(simpleUser())
-                                                                          .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                                                                          .param("roomId", roomId));
-
-    response.andExpect(status().isOk());
-    response.andExpect(content().string("Room muted successfully"));
-
-    verify(chatNotificationService, times(1)).toggleMutePrivateRoom(SIMPLE_USER, roomId);
-  }
-
-  @Test
   void testNotify() throws Exception {
     PropertyManager.setProperty(MATRIX_JWT_SECRET, "InsufficientToken");
     String jsonNotification =
@@ -644,5 +630,20 @@ class MatrixRestTest {
                                                                                    .contentType(MediaType.APPLICATION_JSON));
 
     response.andExpect(status().isOk());
+  }
+
+  @Test
+  void getMatrixId() throws Exception {
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/findId/demo").with(simpleUser())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED));
+
+    response.andExpect(status().isNotFound());
+
+    when(matrixService.getMatrixIdForUser("demo")).thenReturn("@demo:matrix.exo.tn");
+    response = mockMvc.perform(get(REST_PATH + "/findId/demo").with(simpleUser())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED));
+
+    response.andExpect(status().isOk());
+    response.andExpect(content().string("@demo:matrix.exo.tn"));
   }
 }

--- a/services/src/test/java/io/meeds/chat/upgrade/RemoveProfilePropertyUpgradePluginTest.java
+++ b/services/src/test/java/io/meeds/chat/upgrade/RemoveProfilePropertyUpgradePluginTest.java
@@ -1,0 +1,29 @@
+package io.meeds.chat.upgrade;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.profileproperty.model.ProfilePropertySetting;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+class RemoveProfilePropertyUpgradePluginTest {
+
+  @Test
+  void processUpgrade() {
+    ProfilePropertyService profilePropertyService = mock(ProfilePropertyService.class);
+    SettingService settingService = mock(SettingService.class);
+    ProfilePropertySetting profilePropertySetting = new ProfilePropertySetting();
+    profilePropertySetting.setPropertyName("matrixId");
+    profilePropertySetting.setId(1L);
+    when(profilePropertyService.getProfileSettingByName("matrixId")).thenReturn(profilePropertySetting);
+    RemoveProfilePropertyUpgradePlugin removeProfilePropertyUpgradePlugin =
+                                                                          new RemoveProfilePropertyUpgradePlugin(settingService,
+                                                                                                                 new InitParams(),
+                                                                                                                 profilePropertyService);
+    removeProfilePropertyUpgradePlugin.processUpgrade("1.0", "2.0");
+    verify(profilePropertyService, times(1)).deleteProfilePropertySetting(anyLong());
+  }
+}

--- a/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -78,69 +78,6 @@
   </external-component-plugins>
 
   <external-component-plugins>
-    <target-component>org.exoplatform.social.core.profileproperty.ProfilePropertyService</target-component>
-    <component-plugin>
-      <name>extendProfileProperties</name>
-      <set-method>addProfilePropertyPlugin</set-method>
-      <type>org.exoplatform.social.core.profileproperty.ProfilePropertyDatabaseInitializer</type>
-      <description>this listener populate profile property settings data for the first launch</description>
-      <init-params>
-        <value-param>
-          <name>checkDatabaseAlgorithm</name>
-          <description>check database</description>
-          <value>entry</value>
-        </value-param>
-        <value-param>
-          <name>updateProperties</name>
-          <description>Update existing properties</description>
-          <value>true</value>
-        </value-param>
-        <object-param>
-          <name>configuration</name>
-          <description>description</description>
-          <object type="org.exoplatform.social.core.profileproperty.ProfilePropertyConfig">
-            <field name="profileProperties">
-              <collection type="java.util.ArrayList">
-                <value>
-                  <object type="org.exoplatform.social.core.profileproperty.ProfileProperty">
-                    <field name="propertyName">
-                      <string>matrixId</string>
-                    </field>
-                    <field name="visible">
-                      <boolean>false</boolean>
-                    </field>
-                    <field name="editable">
-                      <boolean>false</boolean>
-                    </field>
-                    <field name="active">
-                      <boolean>true</boolean>
-                    </field>
-                    <field name="required">
-                      <boolean>false</boolean>
-                    </field>
-                    <field name="multiValued">
-                      <boolean>false</boolean>
-                    </field>
-                    <field name="groupSynchronized">
-                      <boolean>false</boolean>
-                    </field>
-                    <field name="propertyType">
-                      <string>text</string>
-                    </field>
-                    <field name="order">
-                      <int>100</int>
-                    </field>
-                  </object>
-                </value>
-              </collection>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
     <target-component>org.exoplatform.web.filter.ExtensibleFilter</target-component>
     <component-plugin>
       <name>Filter useful to set a JWT for authentication o Matrix</name>
@@ -216,6 +153,39 @@
           <name>plugin.upgrade.target.version</name>
           <description>The plugin target version</description>
           <value>7.0.0</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>100</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>The plugin must be executed only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>MatrixRemoveProfileProperty</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.chat.upgrade.RemoveProfilePropertyUpgradePlugin</type>
+      <description>Remove Matrix ID profile property</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>The plugin target version</description>
+          <value>7.1.0</value>
         </value-param>
         <value-param>
           <name>plugin.execution.order</name>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/PopoverChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/PopoverChatButton.vue
@@ -50,14 +50,13 @@ export default {
       event.preventDefault();
       event.stopPropagation();
       if(this.identityType === 'USER_TIPTIP') {
-        this.$userService.getUser(this.identityId, 'settings').then(data => {
-          const matrixIdProperty = data.properties.filter(p => p.propertyName == 'matrixId').shift();
-          if(matrixIdProperty) {
-            const contactMatrixId = matrixIdProperty.value;
+        this.$userService.getUser(this.identityId).then(data => {
+          const userName = data.userName || data.username;
+          this.$matrixService.getMatrixIdOfUser(userName).then(contactMatrixId => {
             if(contactMatrixId) {
               this.$matrixService.openDMRoom(eXo.env.portal.userName, data.userName, matrixServerName, matrixUserId, contactMatrixId);
             }
-          }
+          });
         });
       } else if (this.identityType === 'space'){
         this.$matrixService.openSpaceRoom(this.identityId);

--- a/webapp/src/main/webapp/vue-apps/matrix/extension.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/extension.js
@@ -9,11 +9,12 @@ export function registerChatExtensions(chatTitle) {
     iconOnly: true,
     order: 10,
     enabled: async function(identity) {
-      if(identity.userName || identity.username) {
-        const userMatrixId = identity.properties?.some(property => property.propertyName === 'matrixId') && identity.properties?.find(property => property.propertyName === 'matrixId').value;
+      const userIdentifier = identity.userName || identity.username;
+      if (userIdentifier) {
+        const matrixUserId = await matrixService.getMatrixIdOfUser(userIdentifier);
         return identity?.enabled && identity.username !== eXo.env.portal.userName
                && localStorage.getItem("matrix_user_id")
-               && userMatrixId;
+               && matrixUserId;
       } else {
         const room = await matrixService.getSpaceRoom(identity.id);
         return room.status === 'ENABLED';
@@ -22,11 +23,11 @@ export function registerChatExtensions(chatTitle) {
     click: (profile) => {
       const userName = profile.userName || profile.username;
       if(userName) {
-        const matrixProperty = profile.properties.filter(property => property.propertyName === 'matrixId');
-        if(matrixProperty && matrixProperty.length > 0) {
-          const invitedUserMatrixId = matrixProperty[0].value;
-          matrixService.openDMRoom(eXo.env.portal.userName, userName, matrixServerName, matrixUserId, invitedUserMatrixId);
-        }
+        matrixService.getMatrixIdOfUser(userName).then(invitedUserMatrixId => {
+          if (invitedUserMatrixId) {
+            matrixService.openDMRoom(eXo.env.portal.userName, userName, matrixServerName, matrixUserId, invitedUserMatrixId);
+          }
+        });
       } else {
         matrixService.openSpaceRoom(profile.id);
       }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -1636,3 +1636,19 @@ export async function resetUnseenOnFirstMessageSeen(roomId, userId) {
   }
   return false;
 }
+
+export function getMatrixIdOfUser(userId) {
+  if (!userId) {
+    return;
+  }
+  return fetch(`/matrix/rest/matrix/findId/${userId}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (resp?.ok) {
+      return resp.text();
+    } else {
+      throw new Error('Get Matrix Id of user : Response code indicates a server error', resp);
+    }
+  });
+}


### PR DESCRIPTION
Removed the profile property setting matrixId, and used a dedicated rest call to retrieve the user matrix ID instead of loading it from the user profile properties.
