### PR TITLE
fix: reset typing state after sending the message - MEED-9834 - Meeds-io/meeds#3774

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/message/MessageComposer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/message/MessageComposer.vue
@@ -258,6 +258,7 @@ export default {
 
       const eventId = await this.$matrixService.sendMessage(message, this.room.id);
       this.$matrixService.markMessageAsRead(this.room.id, eventId);
+      this.$matrixService.sendTyping(this.room.id, false);
       if (!this.messageToEdit) {
         this.$root.$emit('message-sent-statistics', message, this.room);
       }


### PR DESCRIPTION
reset typing state after sending the message