### PR TITLE
fix: remove mx-reply tag from the content body of the reply of a message - MEED-9232

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -1295,7 +1295,7 @@ export async function buildReplyToObject(messages, eventId) {
                                               && !parentEvent?.content?.['org.matrix.msc2516.voice']);
 
   const replyToObject = {
-    body: parentEvent.content.body,
+    body: parentEvent.content.body?.replace(/<mx-reply>.*?<\/mx-reply>/, ''),
     isReplyToReply: isReplyToReply,
     targetUser: targetUser,
     targetEventId: targetEventId,


### PR DESCRIPTION
Sometimes the content of a reply message contains the HTML representation of the reply-to message inside a specific tag <mx-reply>.
According to [the specification (v1.13)](https://spec.matrix.org/latest/client-server-api/#rich-replies) this tag should be removed by clients 