### PR TITLE
fix: Make sure to use latest message eventId when marking room as fully read - MEED-9932 - Meeds-io/meeds#3824

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomMessages.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomMessages.vue
@@ -392,21 +392,9 @@ export default {
       this.$set(this.messages, index, redacted);
       this.updateUnseenOnMessageDelete(redactedEventId, index);
     },
-    getLatestMessageEventId() {
-      const ordered = [...this.messages].sort(
-        (a, b) => (b?.updatedAt || b.origin_server_ts || 0) - (a?.updatedAt || a.origin_server_ts || 0)
-      );
-
-      for (const msg of ordered) {
-        if (msg?.type === 'm.room.message') {
-          return msg?.replacementEventId || msg?.event_id || null;
-        }
-      }
-      return null;
-    },
-    markRoomAsRead(roomId) {
+    async markRoomAsRead(roomId) {
       if (this.messages?.length) {
-        const eventId = this.getLatestMessageEventId();
+        const eventId = await this.$matrixService.getRoomLastMessageEventId(roomId);
         if (eventId === this.lastMarkedReadEventId) {
           return;
         }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -1061,6 +1061,40 @@ export async function markRoomAsFullyRead(roomId, eventId) {
   }
 }
 
+export async function getRoomLastMessageEventId(roomId) {
+  const filter = {
+    types: ['m.room.message']
+  };
+
+  const baseUrl = `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/messages`;
+  const params = new URLSearchParams({
+    dir: 'b',
+    limit: '1',
+    filter: JSON.stringify(filter)
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}?${params.toString()}`, {
+      headers: {
+        'Authorization': `Bearer ${localStorage.getItem('matrix_access_token')}`
+      }
+    });
+
+    if (!response.ok) {
+      console.error('Failed to fetch latest message:', await response.text());
+      return null;
+    }
+
+    const data = await response.json();
+    const lastMessage = data?.chunk?.[0];
+    return lastMessage?.event_id || null;
+
+  } catch (err) {
+    console.error('Error fetching latest message:', err);
+    return null;
+  }
+}
+
 export async function formatMessage(message, room) {
   if (!message) {
     return '';


### PR DESCRIPTION
Make sure to use latest message eventId when marking room as fully read