### PR TITLE
feat allow configuring multiple groups that can access chat - MEED-10032

### DIFF
--- a/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
@@ -124,14 +124,12 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
     }
     Space space = event.getSpace();
     String userId = event.getTarget();
-    String restrictedGroupOfUsers = PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP);
+    String[] restrictedGroupOfUsers = this.matrixService.getRestrictedGroups();
     String matrixUserAdmin = PropertyManager.getProperty(MATRIX_ADMIN_USERNAME);
     String matrixIdOfUser = matrixService.getMatrixIdForUser(userId);
     try {
-      if (StringUtils.isBlank(matrixIdOfUser)
-          && (StringUtils.isBlank(restrictedGroupOfUsers) || (StringUtils.isNotBlank(restrictedGroupOfUsers)
-              && this.matrixService.isUserMemberOfGroup(userId, restrictedGroupOfUsers)))
-          && !userId.equals(matrixUserAdmin)) {
+      if (StringUtils.isBlank(matrixIdOfUser) && (restrictedGroupOfUsers == null || restrictedGroupOfUsers.length == 0
+          || (this.matrixService.isUserMemberOfGroups(userId, restrictedGroupOfUsers))) && !userId.equals(matrixUserAdmin)) {
         Identity user;
         user = identityManager.getOrCreateUserIdentity(userId);
         matrixIdOfUser = matrixService.saveUserAccount(user, true);

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixUserListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixUserListener.java
@@ -70,9 +70,9 @@ public class MatrixUserListener extends UserEventListener {
       return;
     }
     String matrixUserAdmin = PropertyManager.getProperty(MATRIX_ADMIN_USERNAME);
-    String matrixRestrictedGroup = PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP);
-    if ((StringUtils.isNotBlank(matrixRestrictedGroup)
-        && !this.matrixService.isUserMemberOfGroup(user.getUserName(), matrixRestrictedGroup))
+    String[] matrixRestrictedGroups = matrixService.getRestrictedGroups();
+    if ((matrixRestrictedGroups != null && matrixRestrictedGroups.length > 0
+        && !this.matrixService.isUserMemberOfGroups(user.getUserName(), matrixRestrictedGroups))
         || matrixUserAdmin.equals(user.getUserName())) {
       return;
     }

--- a/services/src/main/java/io/meeds/chat/listeners/MatrixUserLoginListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixUserLoginListener.java
@@ -43,19 +43,19 @@ import static io.meeds.chat.service.utils.MatrixConstants.MATRIX_RESTRICTED_USER
 @Component
 public class MatrixUserLoginListener extends Listener<ConversationRegistry, ConversationState> {
 
-  private static final Log    LOG = ExoLogger.getLogger(MatrixUserLoginListener.class);
+  private static final Log LOG = ExoLogger.getLogger(MatrixUserLoginListener.class);
 
   @Autowired
-  private IdentityManager     identityManager;
+  private IdentityManager  identityManager;
 
   @Autowired
-  private MatrixService       matrixService;
+  private MatrixService    matrixService;
 
   @Autowired
-  private ListenerService     listenerService;
+  private ListenerService  listenerService;
 
   @Autowired
-  private UserACL             userACL;
+  private UserACL          userACL;
 
   @PostConstruct
   public void init() {
@@ -63,21 +63,22 @@ public class MatrixUserLoginListener extends Listener<ConversationRegistry, Conv
   }
 
   public void onEvent(Event<ConversationRegistry, ConversationState> event) {
-    if(!matrixService.isServiceAvailable()) {
+    if (!matrixService.isServiceAvailable()) {
       return;
     }
     String userId = event.getData().getIdentity().getUserId();
     Identity connectedUserIdentity = event.getData().getIdentity();
     String matrixUserAdmin = PropertyManager.getProperty(MATRIX_ADMIN_USERNAME);
-    if(matrixUserAdmin.equals(userId)) {
+    if (matrixUserAdmin.equals(userId)) {
       return;
     }
     RequestLifeCycle.begin(PortalContainer.getInstance());
-    String matrixRestrictedGroup = PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP);
-    if (StringUtils.isNotBlank(matrixRestrictedGroup) && !userACL.isUserInGroup(connectedUserIdentity, matrixRestrictedGroup)) {
-      return;
-    }
     try {
+      String[] matrixRestrictedGroups = matrixService.getRestrictedGroups();
+      if (matrixRestrictedGroups != null && matrixRestrictedGroups.length > 0
+          && !matrixService.isUserMemberOfGroups(connectedUserIdentity.getUserId(), matrixRestrictedGroups)) {
+        return;
+      }
       String matrixUserId = matrixService.getMatrixIdForUser(userId);
       if (StringUtils.isBlank(matrixUserId)) {
         org.exoplatform.social.core.identity.model.Identity userIdentity = identityManager.getOrCreateUserIdentity(userId);

--- a/services/src/main/java/io/meeds/chat/service/MatrixService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixService.java
@@ -352,7 +352,9 @@ public class MatrixService {
 
     String matrixUserId = user.getRemoteId();
     if (isNumeric(user.getRemoteId())) {
-      String prefix = StringUtils.isNotBlank(PropertyManager.getProperty(MATRIX_USERNAME_PREFIX)) ? PropertyManager.getProperty(MATRIX_USERNAME_PREFIX) : "u";
+      String prefix =
+                    StringUtils.isNotBlank(PropertyManager.getProperty(MATRIX_USERNAME_PREFIX)) ? PropertyManager.getProperty(MATRIX_USERNAME_PREFIX)
+                                                                                                : "u";
       matrixUserId = prefix + user.getRemoteId();
     }
     matrixUserId = cleanMatrixUsername(matrixUserId);
@@ -538,11 +540,40 @@ public class MatrixService {
     return matrixRoomStorage.getMatrixDMRoomsOfUser(user);
   }
 
-  public boolean isUserMemberOfGroup(String userName, String groupId) throws Exception {
-    this.organizationService = CommonsUtils.getOrganizationService();
-    Collection<Membership> userMemberships = this.organizationService.getMembershipHandler()
-                                                                     .findMembershipsByUserAndGroup(userName, groupId);
-    return !userMemberships.isEmpty();
+  /**
+   * Checks if the user is a member of a group defined by its name
+   * 
+   * @param userName the user name
+   * @param groupId the user group ID
+   * @return true if the user is a member of the group
+   * @throws Exception
+   */
+  private boolean isUserMemberOfGroup(String userName, String groupId) throws Exception {
+    RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
+    try {
+      Collection<Membership> userMemberships = this.organizationService.getMembershipHandler()
+                                                                       .findMembershipsByUserAndGroup(userName, groupId);
+      return !userMemberships.isEmpty();
+    } finally {
+      RequestLifeCycle.end();
+    }
+  }
+
+  /**
+   * Checks if the user is a member of a group defined by its name
+   * 
+   * @param userName the userName
+   * @param groups the list of groups
+   * @return true if the user is a member of the group
+   * @throws Exception
+   */
+  public boolean isUserMemberOfGroups(String userName, String... groups) throws Exception {
+    for (String group : groups) {
+      if (this.isUserMemberOfGroup(userName, group)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -832,5 +863,18 @@ public class MatrixService {
    */
   public String cleanMatrixUsername(String userName) {
     return userName.replaceAll("[^a-zA-Z0-9=_\\-\\.\\/+]+", "-").toLowerCase();
+  }
+
+  /**
+   * Returns the restricted group of users if it is configured
+   * 
+   * @return Array of group names
+   */
+  public String[] getRestrictedGroups() {
+    String groupNames = PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP);
+    if (StringUtils.isBlank(groupNames)) {
+      return new String[] {};
+    }
+    return Arrays.stream(groupNames.split(",")).map(String::trim).toArray(String[]::new);
   }
 }

--- a/services/src/main/java/io/meeds/chat/service/MatrixSynchronizationService.java
+++ b/services/src/main/java/io/meeds/chat/service/MatrixSynchronizationService.java
@@ -26,6 +26,8 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
 import org.exoplatform.social.core.identity.SpaceMemberFilterListAccess;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
@@ -37,27 +39,35 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
+
 import static io.meeds.chat.service.utils.MatrixConstants.*;
 
 @Service
 public class MatrixSynchronizationService {
 
-  private static final Log LOG                = ExoLogger.getExoLogger(MatrixSynchronizationService.class);
+  private static final Log    LOG                = ExoLogger.getExoLogger(MatrixSynchronizationService.class);
 
-  private MatrixService    matrixService;
+  private MatrixService       matrixService;
 
-  private SpaceService     spaceService;
+  private SpaceService        spaceService;
 
-  private IdentityManager  identityManager;
+  private OrganizationService organizationService;
 
-  private static final int SPACES_THRESHOLD   = 20;
+  private IdentityManager     identityManager;
 
-  private static final int LOADED_USERS_COUNT = 50;
+  private static final int    SPACES_THRESHOLD   = 20;
 
-  public MatrixSynchronizationService(MatrixService matrixService, SpaceService spaceService, IdentityManager identityManager) {
+  private static final int    LOADED_USERS_COUNT = 50;
+
+  public MatrixSynchronizationService(MatrixService matrixService,
+                                      SpaceService spaceService,
+                                      IdentityManager identityManager,
+                                      OrganizationService organizationService) {
     this.matrixService = matrixService;
     this.spaceService = spaceService;
     this.identityManager = identityManager;
+    this.organizationService = organizationService;
   }
 
   public void synchronizeSpaces() {
@@ -132,83 +142,79 @@ public class MatrixSynchronizationService {
     LOG.info("Start:: create Matrix accounts for users");
     long startupTime = System.currentTimeMillis();
 
-    int checkedUsers = 0;
-    int usersCount = 0;
+    int totalCheckedUsers = 0;
+    int totalUserCount = 0;
 
-    ListAccess<Identity> users = null;
-    try {
-      if (StringUtils.isNotBlank(PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP))) {
-        Space restrictedSpace = spaceService.getSpaceByGroupId(PropertyManager.getProperty(MATRIX_RESTRICTED_USERS_GROUP));
-        if (restrictedSpace != null) {
-          users = identityManager.getSpaceIdentityByProfileFilter(restrictedSpace,
-                                                                  new ProfileFilter(),
-                                                                  SpaceMemberFilterListAccess.Type.MEMBER,
-                                                                  false);
+    ListAccess<User> users = null;
+    String[] restrictedGroups = matrixService.getRestrictedGroups();
+    if (restrictedGroups == null || restrictedGroups.length == 0) {
+      restrictedGroups = new String[] { "/platform/users", "/platform/externals" };
+    }
+
+    for (String group : restrictedGroups) {
+      RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
+      try {
+        users = this.organizationService.getUserHandler().findUsersByGroupId(group);
+        int checkedUsers = 0;
+        int usersCount = users == null ? 0 : users.getSize();
+        if (usersCount == 0) {
+          LOG.warn("No users to migrate in group " + group
+              + ", check that the group has already users, or that its name is wrong in the property matrix.restricted.users.groupId .");
         }
-      } else {
-        users = identityManager.getIdentitiesByProfileFilter(OrganizationIdentityProvider.NAME, new ProfileFilter(), false);
-      }
-      usersCount = users == null ? 0 : users.getSize();
-    } catch (Exception e) {
-      throw new RuntimeException("Error while checking users", e);
-    }
 
-    if (usersCount == 0) {
-      throw new IllegalStateException("No users to migrate, please check the value of the property matrix.restricted.users.groupId or remove it to select all users.");
-    }
-
-    RequestLifeCycle.begin(ExoContainerContext.getCurrentContainer());
-    try {
-      while (checkedUsers < usersCount) {
-        int usersToCheck = usersCount > checkedUsers + LOADED_USERS_COUNT ? LOADED_USERS_COUNT : (usersCount - checkedUsers);
-        Identity[] usersArray = users.load(checkedUsers, usersToCheck);
-        for (Identity user : usersArray) {
-          Identity userIdentity = identityManager.getOrCreateUserIdentity(user.getRemoteId());
-          Profile userProfile = userIdentity.getProfile();
-          String userMatrixId = (String) userProfile.getProperty(USER_MATRIX_ID);
-          String adminOfMatrix = PropertyManager.getProperty(MATRIX_ADMIN_USERNAME);
-          if (StringUtils.isBlank(userMatrixId)) {
-            try {
-              boolean isNew = !user.getRemoteId().equals(adminOfMatrix);
-              userMatrixId = matrixService.saveUserAccount(user, isNew);
-            } catch (InterruptedException ie) {
-              Thread.currentThread().interrupt();
-              LOG.warn("Can not create the user {} on Matrix", user.getRemoteId(), ie.getCause());
-            } catch (Exception e) {
-              LOG.warn("Can not create the user {} on Matrix", user.getRemoteId(), e.getCause());
+        while (checkedUsers < usersCount) {
+          int usersToCheck = usersCount > checkedUsers + LOADED_USERS_COUNT ? LOADED_USERS_COUNT : (usersCount - checkedUsers);
+          User[] usersArray = users.load(checkedUsers, usersToCheck);
+          for (User user : usersArray) {
+            Identity userIdentity = identityManager.getOrCreateUserIdentity(user.getUserName());
+            Profile userProfile = userIdentity.getProfile();
+            String userMatrixId = (String) userProfile.getProperty(USER_MATRIX_ID);
+            String adminOfMatrix = PropertyManager.getProperty(MATRIX_ADMIN_USERNAME);
+            if (StringUtils.isBlank(userMatrixId)) {
+              try {
+                boolean isNew = !userIdentity.getRemoteId().equals(adminOfMatrix);
+                userMatrixId = matrixService.saveUserAccount(userIdentity, isNew);
+              } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Can not create the user {} on Matrix", userIdentity.getRemoteId(), ie.getCause());
+              } catch (Exception e) {
+                LOG.warn("Can not create the user {} on Matrix", userIdentity.getRemoteId(), e.getCause());
+              }
             }
-          }
-          if (StringUtils.isNotBlank(userMatrixId)) {
-            // Update user avatar
-            matrixService.updateUserAvatar(userProfile, userMatrixId);
+            if (StringUtils.isNotBlank(userMatrixId)) {
+              // Update user avatar
+              matrixService.updateUserAvatar(userProfile, userMatrixId);
 
-            // Add user to spaces already sync with Matrix
-            ListAccess<Space> userSpaces = spaceService.getMemberSpaces(user.getRemoteId());
-            Space[] spaceArray = userSpaces.load(0, userSpaces.getSize());
-            for (Space space : spaceArray) {
-              Room room = matrixService.getRoomBySpace(space);
-              if (room != null && StringUtils.isNotBlank(room.getRoomId())) {
-                matrixService.joinUserToRoom(room.getRoomId(), userMatrixId);
+              // Add user to spaces already sync with Matrix
+              ListAccess<Space> userSpaces = spaceService.getMemberSpaces(userIdentity.getRemoteId());
+              Space[] spaceArray = userSpaces.load(0, userSpaces.getSize());
+              for (Space space : spaceArray) {
+                Room room = matrixService.getRoomBySpace(space);
+                if (room != null && StringUtils.isNotBlank(room.getRoomId())) {
+                  matrixService.joinUserToRoom(room.getRoomId(), userMatrixId);
+                }
               }
             }
           }
+          checkedUsers += usersArray.length;
+          LOG.info("Checked Matrix account for {} of {} users", checkedUsers, usersCount);
         }
-        checkedUsers += usersArray.length;
-        LOG.info("Checked Matrix account for {} of {} users", checkedUsers, usersCount);
+        totalCheckedUsers += checkedUsers;
+        totalUserCount += usersCount;
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Error while creating accounts for users on Matrix", ie);
+      } catch (Exception e) {
+        throw new RuntimeException("Error while creating accounts for users on Matrix", e);
+      } finally {
+        RequestLifeCycle.end();
       }
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("Error while creating accounts for users on Matrix", ie);
-    } catch (Exception e) {
-      throw new RuntimeException("Error while creating accounts for users on Matrix", e);
-    } finally {
-      RequestLifeCycle.end();
     }
     LOG.info("Summary :: create Matrix accounts for {} users, {} users were checked with their Matrix accounts, {} accounts failed to be created !",
-             checkedUsers,
-             usersCount,
-             usersCount - checkedUsers);
-    if (usersCount - checkedUsers > 0) {
+             totalCheckedUsers,
+             totalUserCount,
+             totalUserCount - totalCheckedUsers);
+    if (totalUserCount - totalCheckedUsers > 0) {
       throw new RuntimeException("Some user accounts were not synchronized with Matrix!");
     }
     LOG.info("End:: create Matrix accounts for users took {}", System.currentTimeMillis() - startupTime);

--- a/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
+++ b/services/src/main/java/io/meeds/chat/service/utils/MatrixHttpClient.java
@@ -1143,10 +1143,14 @@ public class MatrixHttpClient {
       message.setTimeStamp(Long.parseLong(jsonMessage.getElement("origin_server_ts").getStringValue()));
       if (jsonMessage.getElement("content") != null) {
         JsonValue content = jsonMessage.getElement("content");
-        message.setMessageContent(content.getElement("body").getStringValue());
-        message.setMessageType(content.getElement("msgtype").getStringValue());
-        if ("m.text".equals(message.getMessageType()) && content.getElement("org.matrix.custom.html") != null) {
-          message.setMessageContent(jsonMessage.getElement("formatted_body").getStringValue());
+        if(content.getElement("body") != null) {
+          message.setMessageContent(content.getElement("body").getStringValue());
+        }
+        if (content.getElement("msgtype") != null) {
+          message.setMessageType(content.getElement("msgtype").getStringValue());
+          if ("m.text".equals(message.getMessageType()) && content.getElement("org.matrix.custom.html") != null) {
+            message.setMessageContent(jsonMessage.getElement("formatted_body").getStringValue());
+          }
         }
         JsonValue mentionsElement = content.getElement("m.mentions");
         if (mentionsElement != null) {

--- a/services/src/test/java/io/meeds/chat/service/MatrixSynchronizationServiceTest.java
+++ b/services/src/test/java/io/meeds/chat/service/MatrixSynchronizationServiceTest.java
@@ -20,6 +20,10 @@ package io.meeds.chat.service;
 
 import io.meeds.chat.model.Room;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.organization.impl.UserImpl;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -47,36 +51,72 @@ class MatrixSynchronizationServiceTest {
 
   private IdentityManager      identityManager;
 
+  private OrganizationService  organizationService;
 
   @BeforeEach
   void setUp() throws Exception {
     spaceService = mock(SpaceService.class);
     identityManager = mock(IdentityManager.class);
     matrixService = mock(MatrixService.class);
+    organizationService = mock(OrganizationService.class);
+    UserHandler userHandler = mock(UserHandler.class);
     matrixSynchronizationService = mock(MatrixSynchronizationService.class);
-    ListAccess<Identity> usersListAccess = mock(ListAccess.class);
-    when(usersListAccess.getSize()).thenReturn(3);
+    ListAccess<Identity> userIdentitiesListAccess = mock(ListAccess.class);
+    when(userIdentitiesListAccess.getSize()).thenReturn(3);
+    ListAccess<Identity> nextUserIdentities = mock(ListAccess.class);
+    when(nextUserIdentities.getSize()).thenReturn(3);
     Identity user1Identity = new Identity("user1");
     user1Identity.setRemoteId("user1");
     Identity user2Identity = new Identity("user2");
     user2Identity.setRemoteId("user2");
     Identity user3Identity = new Identity("user3");
     user3Identity.setRemoteId("user3");
+    Identity user4Identity = new Identity("user4");
+    user4Identity.setRemoteId("user4");
+    Identity user5Identity = new Identity("user5");
+    user5Identity.setRemoteId("user5");
     Profile user1Profile = new Profile(user1Identity);
     Profile user2Profile = new Profile(user2Identity);
     Profile user3Profile = new Profile(user3Identity);
+    Profile user4Profile = new Profile(user4Identity);
+    Profile user5Profile = new Profile(user5Identity);
     user1Profile.setProperty(USER_MATRIX_ID, "user1");
     user2Profile.setProperty(USER_MATRIX_ID, "user2");
     user3Profile.setProperty(USER_MATRIX_ID, "user3");
+    user4Profile.setProperty(USER_MATRIX_ID, "user4");
+    user5Profile.setProperty(USER_MATRIX_ID, "user5");
     user1Identity.setProfile(user1Profile);
     user2Identity.setProfile(user2Profile);
     user3Identity.setProfile(user3Profile);
-    when(usersListAccess.load(anyInt(), anyInt())).thenReturn(new Identity[] { user1Identity, user2Identity, user3Identity });
-    when(identityManager.getIdentitiesByProfileFilter(eq(OrganizationIdentityProvider.NAME), any(ProfileFilter.class), anyBoolean())).thenReturn(usersListAccess);
+    user4Identity.setProfile(user4Profile);
+    user5Identity.setProfile(user5Profile);
+    when(userIdentitiesListAccess.load(anyInt(), anyInt())).thenReturn(new Identity[] { user1Identity, user2Identity, user3Identity });
+    when(nextUserIdentities.load(anyInt(), anyInt())).thenReturn(new Identity[] { user1Identity, user4Identity, user5Identity });
+    when(identityManager.getIdentitiesByProfileFilter(eq(OrganizationIdentityProvider.NAME),
+                                                      any(ProfileFilter.class),
+                                                      anyBoolean())).thenReturn(userIdentitiesListAccess).thenReturn(nextUserIdentities);
 
     when(identityManager.getOrCreateUserIdentity("user1")).thenReturn(user1Identity);
     when(identityManager.getOrCreateUserIdentity("user2")).thenReturn(user2Identity);
     when(identityManager.getOrCreateUserIdentity("user3")).thenReturn(user3Identity);
+    when(identityManager.getOrCreateUserIdentity("user4")).thenReturn(user4Identity);
+    when(identityManager.getOrCreateUserIdentity("user5")).thenReturn(user5Identity);
+
+    User user1 = new UserImpl("user1");
+    User user2 = new UserImpl("user2");
+    User user3 = new UserImpl("user3");
+    User user4 = new UserImpl("user4");
+    User user5 = new UserImpl("user5");
+    ListAccess<User> usersListAccess = mock(ListAccess.class);
+    when(usersListAccess.load(anyInt(), anyInt())).thenReturn(new User[] { user1, user2, user3 });
+    when(usersListAccess.getSize()).thenReturn(3);
+    
+    ListAccess<User> externalsListAccess = mock(ListAccess.class);
+    when(externalsListAccess.load(anyInt(), anyInt())).thenReturn(new User[] { user1, user4, user5 });
+    when(externalsListAccess.getSize()).thenReturn(3);
+    when(organizationService.getUserHandler()).thenReturn(userHandler);
+    when(organizationService.getUserHandler().findUsersByGroupId("/platform/users")).thenReturn(usersListAccess);
+    when(organizationService.getUserHandler().findUsersByGroupId("/platform/externals")).thenReturn(externalsListAccess);
 
     Space space = new Space();
     space.setId(1);
@@ -89,10 +129,12 @@ class MatrixSynchronizationServiceTest {
     // spaces data
     when(spaceService.getAllSpacesByFilter(any())).thenReturn(spaces);
 
-    matrixSynchronizationService = new MatrixSynchronizationService(matrixService, spaceService, identityManager);
+    matrixSynchronizationService = new MatrixSynchronizationService(matrixService,
+                                                                    spaceService,
+                                                                    identityManager,
+                                                                    organizationService);
 
   }
-
 
   @Test
   void synchronizeSpaces() throws Exception {
@@ -107,7 +149,6 @@ class MatrixSynchronizationServiceTest {
     room.setSpaceId("1");
     when(matrixService.getRoomBySpace(any())).thenReturn(room);
 
-
     matrixSynchronizationService.synchronizeSpaces();
     verify(matrixService, times(1)).createRoom(any());
     verify(matrixService, times(2)).updateRoomAvatar(any(), anyString());
@@ -116,6 +157,6 @@ class MatrixSynchronizationServiceTest {
   @Test
   void synchronizeUsers() throws JsonException, IOException, InterruptedException {
     matrixSynchronizationService.synchronizeUsers();
-    verify(matrixService, times(3)).updateUserAvatar(any(), anyString());
+    verify(matrixService, times(6)).updateUserAvatar(any(), anyString());
   }
 }

--- a/webapp/src/main/webapp/WEB-INF/jsp/matrix.jsp
+++ b/webapp/src/main/webapp/WEB-INF/jsp/matrix.jsp
@@ -7,12 +7,12 @@
 <%@page import="org.exoplatform.services.security.ConversationState"%>
 <%@page import="org.exoplatform.services.security.Identity"%>
 <%
-String matrixRestrictedGroup = PropertyManager.getProperty(MatrixConstants.MATRIX_RESTRICTED_USERS_GROUP);
-UserACL userACL = CommonsUtils.getService(UserACL.class);
 MatrixService matrixService = CommonsUtils.getService(MatrixService.class);
 Identity userIdentity = ConversationState.getCurrent().getIdentity();
+String[] restrictedGroups = matrixService.getRestrictedGroups();
 
-if (matrixService.isServiceAvailable() && (StringUtils.isBlank(matrixRestrictedGroup) || userACL.isUserInGroup(userIdentity, matrixRestrictedGroup))) {
+if (matrixService.isServiceAvailable() && (restrictedGroups == null || restrictedGroups.length == 0
+    || (restrictedGroups != null && restrictedGroups.length > 0 && matrixService.isUserMemberOfGroups(userIdentity.getUserId(), restrictedGroups)))) {
 %>
 <div class="VuetifyApp">
   <div data-app="true"


### PR DESCRIPTION
Currently, it is possible to specify a single group as the one able to access the chat.
The current improvement allows to specify multiple groups of users who are able to access and use the Chat application.
