### PR TITLE
fix: reset all user data in case the matrix ID changes - MEED-9492

### DIFF
--- a/webapp/src/main/webapp/groovy/template/UIMatrixHeadTemplate.gtmpl
+++ b/webapp/src/main/webapp/groovy/template/UIMatrixHeadTemplate.gtmpl
@@ -1,22 +1,18 @@
 <%
   import org.exoplatform.commons.utils.PropertyManager;
   import org.exoplatform.commons.utils.CommonsUtils;
-  import org.exoplatform.social.core.manager.IdentityManager;
-  import org.exoplatform.social.core.identity.model.Identity;
-  import org.exoplatform.social.core.identity.model.Profile;
   import io.meeds.chat.service.utils.MatrixConstants;
+  import io.meeds.chat.service.MatrixService;
 
-  IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+  MatrixService matrixService = CommonsUtils.getService(MatrixService.class);
   def requestContext = _ctx.getRequestContext();
   def userName = requestContext.getRemoteUser();
-  Identity userIdentity = identityManager.getOrCreateUserIdentity(userName);
-  String userMatrixId = "";
-  if(userIdentity != null) {
-    Profile userProfile = userIdentity.getProfile();
-    userMatrixId = "@" + userProfile.getProperty(MatrixConstants.USER_MATRIX_ID) + ":" + PropertyManager.getProperty(MatrixConstants.MATRIX_SERVER_NAME);
+  String userMatrixId = matrixService.getMatrixIdForUser(userName);
+  if(userMatrixId != null) {
+    userMatrixId = "@" + userMatrixId + ":" + PropertyManager.getProperty(MatrixConstants.MATRIX_SERVER_NAME);
   }
 %>
-<script type="text/javascript">
-  matrixServerName = '<%= PropertyManager.getProperty(MatrixConstants.MATRIX_SERVER_NAME) %>';
-  matrixUserId = '<%= userMatrixId %>';
-</script>
+  <script type="text/javascript">
+    matrixServerName = '<%= PropertyManager.getProperty(MatrixConstants.MATRIX_SERVER_NAME) %>';
+    matrixUserId = '<%= userMatrixId %>';
+  </script>

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -648,9 +648,6 @@ export async function startMatrixSyncLoop(matrixFilterId) {
   while (isPolling) {
     try {
       const response = await sync(matrixFilterId || '0', since, MATRIX_SYNC_TIMEOUT);
-      if (response.status === 502) {
-        continue;
-      }
       if (response.status === 401) {
         console.warn('Unauthorized! Token may be expired.');
         // Optionally stop polling or try to refresh token
@@ -1740,12 +1737,14 @@ export function dropUserData() {
   localStorage.removeItem('matrix_user_id');
   localStorage.removeItem('matrix_access_token');
   localStorage.removeItem('matrix_last_login');
+  localStorage.removeItem(MATRIX_SYNC_SINCE);
 }
 
 export function initUserData(data) {
   localStorage.setItem('matrix_user_id', data.user_id);
   localStorage.setItem('matrix_access_token', data.access_token);
   localStorage.setItem('matrix_last_login', new Date().getTime());
+  localStorage.removeItem(MATRIX_SYNC_SINCE);
 }
 
 export async function registerUserToken() {


### PR DESCRIPTION
When the domain of the Matrix server changes, logged-in users encounter troubles getting the rooms and new messages.
The fix re-initiate correctly the matrix identifier and drops all the old  user data