### PR TITLE
fix: notifications failed to be sent when usernames are in email format - MEED-10148

### DIFF
--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -688,9 +688,13 @@ public class MatrixRest implements ResourceContainer {
   private String checkAndParseUserFromToken(String token) {
     byte[] secret = PropertyManager.getProperty(MATRIX_JWT_SECRET).getBytes();
     Jws<Claims> jws = Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(secret)).build().parseClaimsJws(token);
-    String username = String.valueOf(jws.getBody().getSubject());
-    if (identityManager.identityExisted(OrganizationIdentityProvider.NAME, username)) {
-      return username;
+    String usernameOnMatrix = String.valueOf(jws.getBody().getSubject());
+    if (StringUtils.isNotBlank(usernameOnMatrix)) {
+      String fullUserName = matrixService.getUserFullMatrixID(usernameOnMatrix);
+      String userName = matrixService.findUserByMatrixId(fullUserName);
+      if (identityManager.identityExisted(OrganizationIdentityProvider.NAME, userName)) {
+        return userName;
+      }
     }
     return null;
   }

--- a/services/src/main/java/io/meeds/chat/service/ChatNotificationService.java
+++ b/services/src/main/java/io/meeds/chat/service/ChatNotificationService.java
@@ -64,7 +64,8 @@ import static io.meeds.chat.service.utils.MatrixConstants.*;
 import static io.meeds.pwa.service.PwaNotificationService.*;
 
 /**
- * This service creates and manages all different notifications related to the chat application
+ * This service creates and manages all different notifications related to the
+ * chat application
  */
 @Service
 public class ChatNotificationService {
@@ -253,8 +254,7 @@ public class ChatNotificationService {
     String roomName = "";
     String senderFullName = "";
     String roomAvatarUrl = "";
-    if (message != null && message.getMentionedUsers() != null && !message.getMentionedUsers().isEmpty()
-        && message.getMentionedUsers().contains(matrixReceiverId)) {
+    if (message != null && isUserIncludedInMentions(message, matrixReceiverId)) {
       Identity senderIdentity = identityManager.getOrCreateUserIdentity(matrixService.findUserByMatrixId(message.getSender()));
       if (senderIdentity != null) {
         senderFullName = senderIdentity.getProfile().getFullName();
@@ -287,6 +287,19 @@ public class ChatNotificationService {
     }
     return false;
   }
+
+  private boolean isUserIncludedInMentions(MatrixMessage message, String matrixReceiverId) {
+      if (message.getMentionedUsers() == null || message.getMentionedUsers().isEmpty()) {
+        return false;
+      }
+
+      boolean isUserMentioned = false;
+      for (String mentionedMatrixId : message.getMentionedUsers()) {
+        mentionedMatrixId = "@" + mentionedMatrixId.substring(1).replace("@", "-");// In case the username is the user email
+        isUserMentioned = mentionedMatrixId.equals(matrixReceiverId);
+      }
+      return isUserMentioned;
+    }
 
   public boolean isPrivateRoomMutedForUser(String userName, String roomId) {
     return getMutedRooms(userName).contains(roomId);

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -792,9 +792,11 @@ export function getUserByMatrixId(userIdOnMatrix, room) {
     return Promise.resolve(null);
   }
 
-  const matrixId = userIdOnMatrix.startsWith('@')
+  let matrixId = userIdOnMatrix.startsWith('@')
     ? userIdOnMatrix.slice(1, userIdOnMatrix.indexOf(':'))
     : userIdOnMatrix;
+
+  matrixId = matrixId.replace('@', '-');
 
   const cachedUser = userCache.get(matrixId);
   if (cachedUser) {
@@ -1106,12 +1108,14 @@ export async function formatMessage(message, room) {
 
   const replacements = await Promise.all(
     mentions.map(async ([fullMatch, matrixId, displayName]) => {
-      const user = await getUserByMatrixId(matrixId, room);
+      let matrixIdWithoutSpecialChar = matrixId.substring(1).replaceAll('@', '-');
+      matrixIdWithoutSpecialChar = '@' + matrixIdWithoutSpecialChar;
+      const user = await getUserByMatrixId(matrixIdWithoutSpecialChar, room);
       const userId = user?.remoteId;
       if (!userId) {
         return fullMatch;
       }
-      const mentionedDisplayName = user?.profile?.fullname || displayName || matrixId;
+      const mentionedDisplayName = user?.profile?.fullname || displayName || matrixIdWithoutSpecialChar;
       const profileUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${userId}`;
       const formatted = `<a href="${profileUrl}" class="font-weight-bold text-decoration-none" target="_blank">@${mentionedDisplayName}</a>`;
       return { fullMatch, formatted };
@@ -1667,7 +1671,8 @@ export async function getUserIdentity(userId) {
 
 function extractUserIdFromRoomMembers(room, matrixId) {
   if (room.spaceId) {
-    return room.members.find(member => member.matrixId === matrixId || matrixId === `@${  member.matrixId  }:${  matrixServerName}`)?.userId;
+    return room.members.find(member => member.matrixId === matrixId
+                                       || matrixId === `@${  member.matrixId }:${  matrixServerName}`)?.userId;
   }
   return matrixId === matrixUserId ? eXo.env.portal.userName : room.userId;
 }


### PR DESCRIPTION
Synapse automatically changes the usernames when they contain the @ character and replace it with dash. But when sending the notification, it uses the matrix ID with the @ character instead. The fix checks the character in the returned matrix ID and does the needed replacement to match correctly the matrix ID of the notified user.

(cherry picked from commit 5febd6554f99eea7655cf9fb660750b6f2fe26e9)