### PR TITLE
fix: sanitize room item IDs to ensure valid HTML - MEED-10200 - Meeds-io/meeds#4028

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -139,7 +139,8 @@ export default {
   },
   computed: {
     roomItemTagId() {
-      return `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
+      const rawId = `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
+      return rawId.replaceAll(/[^A-Za-z0-9\-_:.]/g, '_');
     },
     isSelected() {
       return this.selectedRoom?.id === this.room?.id;


### PR DESCRIPTION
prior to this change, the `roomItemTagId()` function could generate invalid HTML IDs if `spaceId` or `dmMemberId` contained characters like '@', spaces, or other special symbols. This caused issues when using these IDs in the DOM. 
This PR replaces all invalid HTML ID characters with underscores (`_`), to ensure valid HTML tag ID.