### PR TITLE
fix: sanitize generated room item HTML id to remove unsupported characters (including dots) - MEED-10200 - Meeds-io/meeds#4028

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -139,7 +139,8 @@ export default {
   },
   computed: {
     roomItemTagId() {
-      return `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
+      const rawId = `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
+      return rawId.replaceAll(/[^A-Za-z0-9\-_:.]/g, '_');
     },
     isSelected() {
       return this.selectedRoom?.id === this.room?.id;

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -140,7 +140,7 @@ export default {
   computed: {
     roomItemTagId() {
       const rawId = `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
-      return rawId.replaceAll(/[^A-Za-z0-9\-_:.]/g, '_');
+      return rawId.replaceAll(/[^A-Za-z0-9_-]/g, '_');
     },
     isSelected() {
       return this.selectedRoom?.id === this.room?.id;


### PR DESCRIPTION
Prior to this change, the generated HTML id could contain dots and other non-alphanumeric characters coming from spaceId or dmMemberId.

Although dots are technically valid in HTML ids, they cause issues when used in CSS selectors (requiring escaping) and can lead to unexpected behavior in querySelector usage.

This change restricts the id to [A-Za-z0-9_-] only and replaces any other character with an underscore to ensure safe and predictable DOM, CSS, and JavaScript usage.

(cherry-Picked from https://github.com/Meeds-io/matrix/pull/489 & https://github.com/Meeds-io/matrix/pull/488