### PR TITLE
fix: sanitize generated room item HTML id to remove unsupported characters (including dots) - MEED-10200 - Meeds-io/meeds#4028 (#490)

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRoom.vue
@@ -139,7 +139,8 @@ export default {
   },
   computed: {
     roomItemTagId() {
-      return `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
+      const rawId = `room${this.room.spaceId || this.room.dmMemberId}${this.fromRoomList ? 'fromRoomList' : ''}`;
+      return rawId.replaceAll(/[^A-Za-z0-9_-]/g, '_');
     },
     isSelected() {
       return this.selectedRoom?.id === this.room?.id;


### PR DESCRIPTION
prior to this change, the `roomItemTagId()` function could generate invalid HTML IDs if `spaceId` or `dmMemberId` contained characters like '@', spaces, or other special symbols. This caused issues when using these IDs in the DOM. This PR replaces all invalid HTML ID characters with underscores (`_`), to ensure valid HTML tag ID.

(cherry picked from commit 580134b426b532f2fd6838f307b4ed42b76b346d)

Prior to this change, the generated HTML id could contain dots and other non-alphanumeric characters coming from spaceId or dmMemberId.

Although dots are technically valid in HTML ids, they cause issues when used in CSS selectors (requiring escaping) and can lead to unexpected behavior in querySelector usage.

This change restricts the id to [A-Za-z0-9_-] only and replaces any other character with an underscore to ensure safe and predictable DOM, CSS, and JavaScript usage.

(cherry picked from commit c4a28f813eba85e91e4c317fb713ba48cae3aa2b) (cherry picked from commit 4bb3a5c535ec56a97902d0fceb5ca5c40b5043dc)