### PR TITLE
fix: suggest selecting a parent space when creating a circle subspace chat room - MEED-10369 - Meeds-io/meeds#4176

### DIFF
--- a/webapp/src/main/resources/locale/portlet/matrix_en.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_en.properties
@@ -15,6 +15,9 @@ matrix.chat.quick.create.discussion.info=You can choose only one user
 matrix.chat.quick.create.discussion.add.people=Add people
 matrix.chat.quick.discussion.add=Add
 matrix.chat.quick.create.discussion.success.notification=Chat room successfully added.
+matrix.chat.quick.create.subspace.discussion.info=Please, join a parent space to create a chatroom with more than one people
+matrix.chat.quick.create.select.parent.space=Select a parent space
+matrix.chat.load.more.parent.spaces=Load more spaces
 matrix.chat.time.now=Now
 matrix.chat.time.today=Today
 matrix.chat.time.yesterday=Yesterday
@@ -83,4 +86,3 @@ matrix.chat.label.cancelRecording=Cancel recording
 matrix.unread.section.load.exceed=We cannot automatically load the top of unread section
 matrix.chat.file.no.available=File no more available
 matrix.room.members.label=Members
-

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatParentSpaceSelector.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatParentSpaceSelector.vue
@@ -1,0 +1,125 @@
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <div>
+    <div v-if="selecting" class="pa-5">
+      <div class="mb-5 font-weight-bold text-color">
+        {{ $t('matrix.chat.quick.create.select.parent.space') }}
+      </div>
+      <v-list-item
+        v-for="space in parentSpaces"
+        :key="space.id"
+        class="px-0"
+        dense
+        @click="selectSpace(space)">
+        <v-list-item-content>
+          <space-avatar
+            :space="space"
+            class="not-clickable-link text-truncate"
+            list-style />
+        </v-list-item-content>
+      </v-list-item>
+      <div
+        v-if="hasMore"
+        id="parentSpacesListFooter"
+        class="flex-grow-0 flex-shrink-0 pb-5 border-box-sizing">
+        <v-btn
+          :loading="loadingMore"
+          class="loadMoreButton border-color elevation-0 ma-auto"
+          block
+          @click="loadMore">
+          {{ $t('spacesList.button.showMore') }}
+        </v-btn>
+      </div>
+    </div>
+    <div v-else-if="canEdit">
+      <div
+        class="d-flex align-center justify-space-between px-4">
+        <span class="text-body font-weight-bold">
+          {{ $t('matrix.chat.quick.create.select.parent.space') }}
+        </span>
+        <v-btn
+          icon
+          @click="startSelection">
+          <v-icon size="20">
+            fa-edit
+          </v-icon>
+        </v-btn>
+      </div>
+      <div v-if="value" class="px-4">
+        <space-avatar
+          :space="value"
+          class="not-clickable-link text-truncate"
+          list-style />
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+
+export default {
+  props: {
+    value: {
+      type: Object,
+      default: null
+    },
+    parentSpaces: {
+      type: Array,
+      default: () => []
+    },
+    canEdit: {
+      type: Boolean,
+      default: true
+    },
+    hasMore: {
+      type: Boolean,
+      default: false
+    },
+    loadingMore: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      selecting: false
+    };
+  },
+  watch: {
+    selecting() {
+      this.$emit('selecting', this.selecting);
+    }
+  },
+  methods: {
+    selectSpace(space) {
+      this.$emit('input', space);
+      this.selecting = false;
+    },
+    startSelection() {
+      this.selecting = true;
+    },
+    loadMore() {
+      this.$emit('load-more');
+    },
+  }
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatQuickCreateDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatQuickCreateDiscussionDrawer.vue
@@ -25,7 +25,7 @@
     id="QuickCreateDiscussionDrawer"
     right
     @closed="close">
-    <template slot="title">
+    <template #title>
       <span class="d-flex my-auto text-header-title font-weight-bold text-color">
         <v-icon
           size="18"
@@ -36,8 +36,9 @@
         {{ $t('matrix.chat.quick.create.discussion') }}
       </span>
     </template>
-    <template slot="content">
+    <template #content>
       <v-form
+        v-if="!isParentSpaceSelecting"
         id="QuickCreateRoom"
         ref="QuickCreateRoom"
         class="px-2 ms-2 mt-5">
@@ -65,11 +66,26 @@
                 {{ $t('matrix.chat.quick.create.discussion.info') }}.
               </span>
             </div>
+            <div 
+              v-else-if="invitedSpaceMembers && !canCreateSubspacePrivateRoom">
+              <span class="text-subtitle">
+                {{ $t('matrix.chat.quick.create.subspace.discussion.info') }}.
+              </span>
+            </div>
           </div>
         </div>
       </v-form>
+      <matrix-chat-parent-space-selector
+        v-if="invitedSpaceMembers && canCreateSubspacePrivateRoom"
+        v-model="selectedSpace"
+        :parent-spaces="parentSpaceList"
+        :can-edit="parentSpaceList.length > 1"
+        :has-more="hasMoreParentSpaces"
+        :loading-more="loadingMore"
+        @selecting="isParentSpaceSelecting = $event"
+        @load-more="loadMoreParentSpaces" />
     </template>
-    <template slot="footer">
+    <template #footer>
       <div class="d-flex flex-row justify-end">
         <v-btn
           class="me-2 btn"
@@ -94,12 +110,25 @@ export default {
     return {
       participant: null,
       loading: false,
-      spaceCircleTemplate: null
+      spaceCircleTemplate: null,
+      isSubspaceTemplate: false,
+      parentSpaceList: [],
+      parentSpacesSize: 0,
+      parentSpacesLimit: 20,
+      loadingMore: false,
+      selectedSpace: null,
+      isParentSpaceSelecting: false
     };
   },
   computed: {
     canCreatePrivateRooms() {
       return !!this.spaceCircleTemplate;
+    },
+    canCreateSubspacePrivateRoom() {
+      return this.isSubspaceTemplate && this.parentSpaceList.length > 0;
+    },
+    hasMoreParentSpaces() {
+      return this.parentSpaceList.length < this.parentSpacesSize;
     },
     invitedSpaceMembers() {
       return this.participant?.length > 1 && this.participant || null;
@@ -110,11 +139,12 @@ export default {
       };
     },
     disabledSaveButton(){
-      return !this.participant;
-    }
+      return !this.participant || this.invitedSpaceMembers && (!this.canCreateSubspacePrivateRoom || !this.selectedSpace);
+    },
   },
-  created() {
-    this.checkCanCreatePrivateRooms();
+  async created() {
+    await this.checkCanCreatePrivateRooms();
+    await this.getParentSpaces();
     this.$root.$on(this.$chatConstants.ACTION_CHAT_OPEN_QUICK_CREATE_DISCUSSION_DRAWER, this.openDrawer);
   },
   beforeDestroy() {
@@ -126,7 +156,7 @@ export default {
       this.$refs.QuickCreateDiscussionDrawer.open();
     },
     close() {
-      this.participant = null;
+      this.reset();
       this.$refs.QuickCreateDiscussionDrawer.close();
     },
     createPrivateRoom() {
@@ -135,7 +165,8 @@ export default {
         invitedMembers: this.invitedSpaceMembers,
         subscription: this.spaceCircleTemplate.spaceDefaultRegistration?.toLowerCase?.(),
         visibility: this.spaceCircleTemplate.spaceDefaultVisibility?.toLowerCase?.(),
-        templateId: this.spaceCircleTemplate.id
+        templateId: this.spaceCircleTemplate.id,
+        parentSpaceId: this.selectedSpace?.id || 0
       };
       this.$spaceService.createSpace(space).then((createdSpace) => {
         this.openChatRoom(createdSpace.id, true);
@@ -163,17 +194,41 @@ export default {
                                                        || this.participant.remoteId;
       this.openChatRoom(remoteId);
     },
-    checkCanCreatePrivateRooms() {
-      this.$spaceTemplateService.getSpaceTemplates(false).then(templates => {
-        const circleTemplate = templates?.find?.(template => template.system && template.layout === 'circle');
-        if (circleTemplate) {
-          this.$spaceTemplateService.canCreateSpaceWithTemplate(circleTemplate.id).then(data => {
-            if (data?.canCreate) {
-              this.spaceCircleTemplate = circleTemplate;
-            }
-          });
+    async checkCanCreatePrivateRooms() {
+      const templates = await this.$spaceTemplateService.getSpaceTemplates(false);
+      const circleTemplate = templates?.find(template => template.system && template.layout === 'circle' && !template.deleted);
+      this.spaceCircleTemplate = circleTemplate || null;
+      if (this.spaceCircleTemplate) {
+        const subspaceTemplateIds = await this.$spaceTemplateService.getSubspaceTemplateIds() || [];
+        this.isSubspaceTemplate = subspaceTemplateIds.includes(this.spaceCircleTemplate.id);
+      }
+    },
+    async getParentSpaces() {
+      if (this.isSubspaceTemplate) {
+        const data = await this.$spaceService.getSpacesByFilter({
+          offset: 0,
+          limit: this.parentSpacesLimit,
+          subspaceTemplateId: this.spaceCircleTemplate.id,
+          filter: 'accessible'
+        });
+        this.parentSpaceList = data?.spaces || [];
+        this.parentSpacesSize = data?.size || this.parentSpaceList.length;
+        if (this.parentSpacesSize === 1) {
+          this.selectedSpace = this.parentSpaceList[0];
         }
-      });
+      }
+    },
+    async loadMoreParentSpaces() {
+      this.loadingMore = true;
+      this.parentSpacesLimit += 20;
+      await this.getParentSpaces();
+      this.loadingMore = false;
+    },
+    reset() {
+      this.participant = null;
+      this.selectedSpace = null;
+      this.isParentSpaceSelecting = false;
+      this.parentSpacesLimit = 20;
     }
   }
 };

--- a/webapp/src/main/webapp/vue-apps/matrix/main.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/main.js
@@ -6,6 +6,7 @@ import MeedsChatMessage from './components/ChatMessage.vue';
 import MeedsChatMessageContent from './components/ChatMessageContent.vue';
 import MeedsChatQuickCreateDiscussionDrawer from './components/MeedsChatQuickCreateDiscussionDrawer.vue';
 import MeedsChatDiscussionDrawer from './components/MeedsChatDiscussionDrawer.vue';
+import MeedsChatParentSpaceSelector from './components/MeedsChatParentSpaceSelector.vue';
 import PopoverChatButton from './components/PopoverChatButton.vue';
 import AudioMessage from './components/message/AudioMessage.vue';
 import MessageReplyQuote from './components/message/MessageReplyQuote.vue';
@@ -52,6 +53,7 @@ const components = {
   'matrix-popover-chat-button': PopoverChatButton,
   'matrix-chat-quick-create-discussion-drawer': MeedsChatQuickCreateDiscussionDrawer,
   'matrix-chat-discussion-drawer': MeedsChatDiscussionDrawer,
+  'matrix-chat-parent-space-selector': MeedsChatParentSpaceSelector,
   'matrix-audio-message': AudioMessage,
   'matrix-message-reply-quote': MessageReplyQuote,
   'matrix-message-edit-banner': MessageEditBanner,


### PR DESCRIPTION
Prior to this change, it was not possible to create a chat room when the circle template was configured as a subspace template, because subspace creation requires selecting a parent space. This change enables selecting a parent space when creating a space chat room in that context.