### PR TITLE
fix: add missing property to Template - EXO-86224

### DIFF
--- a/webapp/src/main/webapp/groovy/template/UIMatrixHeadTemplate.gtmpl
+++ b/webapp/src/main/webapp/groovy/template/UIMatrixHeadTemplate.gtmpl
@@ -1,12 +1,10 @@
 <%
   import org.exoplatform.commons.utils.PropertyManager;
   import org.exoplatform.commons.utils.CommonsUtils;
-  import org.exoplatform.social.core.manager.IdentityManager;
-  import org.exoplatform.social.core.identity.model.Identity;
-  import org.exoplatform.social.core.identity.model.Profile;
   import io.meeds.chat.service.utils.MatrixConstants;
+  import io.meeds.chat.service.MatrixService;
 
-  IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+  MatrixService matrixService = CommonsUtils.getService(MatrixService.class);
   def requestContext = _ctx.getRequestContext();
   def userName = requestContext.getRemoteUser();
   if (userName != null) {


### PR DESCRIPTION
During the merge of the fix EXO-86224, the declaration of the property matrixService was missing from the template **UIMatrixHeadTemplate.gtmpl**, it was left in an old commit on maintenance branch.
This fix will restore the correct declaration of the property and avoid the problem of the display of the chat button. 
