### PR TITLE
fix: Avoid PWA initialization twice - EXO-87242

### DIFF
--- a/webapp/src/main/java/io/meeds/chat/MatrixApplication.java
+++ b/webapp/src/main/java/io/meeds/chat/MatrixApplication.java
@@ -26,7 +26,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = {
         MatrixApplication.MODULE_NAME,
-        "io.meeds.pwa",
         AvailableIntegration.KERNEL_MODULE,
         AvailableIntegration.JPA_MODULE,
         AvailableIntegration.LIQUIBASE_MODULE,


### PR DESCRIPTION
Prior to this change, the PWA Beans are initialized twice which leads to add listeners twice and executing `@PostContruct` annotated methods twice. This change will avoid initializing PWA beans in Matrix contexts.