### PR TITLE
feat: set room to read only when disabled from spaces administration - Meeds-io/Mips#249 - MEED-10486

### DIFF
--- a/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
+++ b/services/src/main/java/io/meeds/chat/listeners/MatrixSpaceListener.java
@@ -20,13 +20,18 @@ package io.meeds.chat.listeners;
 
 import io.meeds.chat.entity.RoomStatus;
 import io.meeds.chat.model.Room;
+import io.meeds.social.space.plugin.SpaceExtendedPermissionsLifeCycleEvent;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import io.meeds.chat.model.MatrixRoomPermissions;
 import io.meeds.chat.model.MatrixUserPermission;
 import io.meeds.chat.service.MatrixService;
 import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -36,7 +41,9 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
 
@@ -303,5 +310,43 @@ public class MatrixSpaceListener extends SpaceListenerPlugin {
         LOG.error("Could not delete the room {} linked to the space {}", room.getRoomId(), space.getDisplayName());
       }
     }
+  }
+
+  @Override
+  public void extendedPermissionsUpdated(SpaceExtendedPermissionsLifeCycleEvent event) {
+    if (!event.getChangedpermissions().contains(SPACE_CHAT_AUTHORIZED)) {
+      return;
+    }
+    Space space = event.getSpace();
+    Room spaceRoom = matrixService.getRoomBySpace(space);
+    if (spaceRoom == null) {
+      try {
+        // Administrators could force create rooms from the space administration
+        matrixService.createRoom(space);
+      } catch (Exception e) {
+        LOG.error("Could not create room for space {}", space.getDisplayName(), e);
+      }
+    }
+    Map<String, String> extendedPermissions = space.getExtendedPermissions();
+    if (extendedPermissions != null && !extendedPermissions.isEmpty()) {
+      boolean enableChat = "true".equals(extendedPermissions.get(SPACE_CHAT_AUTHORIZED));
+      class EnableChatRunnable implements Runnable {
+        @Override
+        public void run() {
+          ExoContainerContext.setCurrentContainer(PortalContainer.getInstance());
+          RequestLifeCycle.begin(PortalContainer.getInstance());
+          try {
+            matrixService.enableSpaceChat(space, enableChat);
+          } catch (ObjectNotFoundException e) {
+            LOG.error("Could not {} the room of the space {}", enableChat ? "enable" : "disable", space.getDisplayName(), e);
+          } finally {
+            RequestLifeCycle.end();
+          }
+        }
+      }
+      Thread enableThread = new Thread(new EnableChatRunnable(), "Enable members in space Thread");
+      enableThread.start();
+    }
+
   }
 }

--- a/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
+++ b/services/src/main/java/io/meeds/chat/rest/MatrixRest.java
@@ -807,9 +807,9 @@ public class MatrixRest implements ResourceContainer {
         spaceIds.remove(String.valueOf(room.getSpaceId()));
       }
       ChatSettingsEntity chatSettings = matrixService.loadChatSettings();
-      if (RoomStatus.ENABLED.name().equals(room.getStatus()) && (chatSettings == null
-          || (room.isDirectChat() && chatSettings.isPrivateRoomsEnabled())
-          || (!room.isDirectChat() && chatSettings.isSpaceRoomsEnabled() && matrixService.isChatAuthorizedForSpace(room.getSpaceId())))) {
+      if (RoomStatus.ENABLED.name().equals(room.getStatus())
+          && (chatSettings == null || (room.isDirectChat() && chatSettings.isPrivateRoomsEnabled()) || (!room.isDirectChat()
+              && chatSettings.isSpaceRoomsEnabled() && matrixService.isChatAuthorizedForSpace(room.getSpaceId())))) {
         processedRooms.add(room);
       } else {
         // Substract the unread messages from disabled chat rooms

--- a/webapp/src/main/webapp/vue-apps/spaces-administration-extension/components/matrixAuthorizeSpaceChatTemplate.vue
+++ b/webapp/src/main/webapp/vue-apps/spaces-administration-extension/components/matrixAuthorizeSpaceChatTemplate.vue
@@ -18,7 +18,7 @@
 -->
 
 <template>
-  <div>
+  <div v-if="!loading">
     <div class="d-flex">
       <div class="flex-grow-1">
         <div class="d-flex flex-column">
@@ -62,12 +62,20 @@ export default {
     isChatAuthorized: true,
     initialChatState: false,
     chatAuthorizedLabel: 'meeds.chat.authorized',
+    loading: true,
   }),
   created() {
     if (this.space) {
-      this.isChatAuthorized = !this.extendedPermissions || this.extendedPermissions[this.chatAuthorizedLabel] === 'true';
+      this.loading = true;
+      this.$matrixService.getSpaceRoom(this.space.id).then(room => {
+        if (room) {
+          this.isChatAuthorized = !this.extendedPermissions || this.extendedPermissions[this.chatAuthorizedLabel] === 'true';
+        } else {
+          this.isChatAuthorized = false;
+        }
+        this.initialChatState = this.isChatAuthorized;
+      }).finally(() => this.loading = false);
     }
-    this.initialChatState = this.isChatAuthorized;
     // in case of multiple selection, we need to set a default value that will be used if the switch button is not updated
     if (this.spaces) {
       this.$root.$emit('space-administration-permissions-drawer-extended-field-updated', {'key': this.chatAuthorizedLabel, 'value': {[this.chatAuthorizedLabel]: this.isChatAuthorized}});


### PR DESCRIPTION
When the permission AUTHORIZE-CHAT is enabled or disabled in a space, the listener **MatrixSpaceListener** will catch the event and will 
 - set the room as disabled on Meeds server DB.
 - change it to read only on Matrix server.
The fix will update the authorization status on the spaces administration permissions drawer and let the platform administrators to enable/disable a space chat even if the space template does not authorize the chat be default.