### PR TITLE
feat: list a conversation's attachments from the chat header

### DIFF
--- a/webapp/src/main/resources/locale/portlet/matrix_en.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_en.properties
@@ -87,3 +87,7 @@ matrix.chat.label.cancelRecording=Cancel recording
 matrix.unread.section.load.exceed=We cannot automatically load the top of unread section
 matrix.chat.file.no.available=File no more available
 matrix.room.members.label=Members
+matrix.room.attachments.label=Attachments
+matrix.room.attachments.title=Attachments
+matrix.room.attachments.empty=No attachment in this conversation yet
+matrix.chat.download=Download

--- a/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
@@ -49,6 +49,7 @@
       @filter-updated="handleFilterUpdate" />
     <matrix-chat-quick-create-discussion-drawer />
     <matrix-room-action-menu-drawer />
+    <matrix-room-attachments-drawer />
     <matrix-message-read-receipt-list-drawer />
     <exo-confirm-dialog
       ref="deleteConfirmDialog"

--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomAttachmentsDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomAttachmentsDrawer.vue
@@ -1,0 +1,171 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2025 Meeds Association contact@meeds.io
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+
+<template>
+  <exo-drawer
+    ref="attachmentsDrawer"
+    class="matrix-attachments-drawer"
+    right
+    @closed="reset">
+    <template #title>
+      {{ $t('matrix.room.attachments.title') }}
+    </template>
+    <template #content>
+      <div
+        v-if="loading"
+        class="d-flex justify-center align-center pa-8">
+        <v-progress-circular
+          indeterminate
+          color="primary"
+          size="32" />
+      </div>
+      <div
+        v-else-if="!attachments.length"
+        class="d-flex flex-column align-center justify-center pa-8 text-center">
+        <v-icon size="48" class="mb-3 icon-default-color">fa-paperclip</v-icon>
+        <span class="text-subtitle">{{ $t('matrix.room.attachments.empty') }}</span>
+      </div>
+      <v-list v-else class="pa-0">
+        <v-list-item
+          v-for="attachment in attachments"
+          :key="attachment.eventId"
+          class="px-4 attachment-item">
+          <v-list-item-icon class="me-3 my-auto">
+            <v-icon
+              :size="20"
+              :color="iconFor(attachment).color">
+              {{ iconFor(attachment).class }}
+            </v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title class="text-truncate text-color">
+              {{ attachment.name }}
+            </v-list-item-title>
+            <v-list-item-subtitle class="d-flex align-center text-caption">
+              <date-format
+                :value="attachment.timestamp"
+                :format="dateFormat" />
+              <template v-if="attachment.size">
+                <span class="mx-1">·</span>{{ formatSize(attachment.size) }}
+              </template>
+            </v-list-item-subtitle>
+          </v-list-item-content>
+          <v-list-item-action class="ma-0">
+            <v-btn
+              :title="$t('matrix.chat.download')"
+              :loading="attachment.downloading"
+              icon
+              @click="download(attachment)">
+              <v-icon size="18" class="icon-default-color">fa-download</v-icon>
+            </v-btn>
+          </v-list-item-action>
+        </v-list-item>
+      </v-list>
+    </template>
+  </exo-drawer>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      room: null,
+      attachments: [],
+      loading: false,
+      dateFormat: {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      },
+    };
+  },
+  created() {
+    this.$root.$on('show-room-attachments', this.open);
+  },
+  beforeDestroy() {
+    this.$root.$off('show-room-attachments', this.open);
+  },
+  methods: {
+    open(room) {
+      this.room = room;
+      this.attachments = [];
+      this.$refs.attachmentsDrawer.open();
+      // Render above the chat drawer (which sits at z-index 1035).
+      this.$nextTick(() => {
+        const el = this.$refs.attachmentsDrawer?.$el;
+        if (el) {
+          el.style.zIndex = '2001';
+        }
+      });
+      this.load();
+    },
+    load() {
+      if (!this.room?.id) {
+        return;
+      }
+      this.loading = true;
+      this.$matrixService.loadRoomAttachments(this.room.id)
+        .then(list => this.attachments = list)
+        .catch(e => console.error('Failed to load room attachments:', e))
+        .finally(() => this.loading = false);
+    },
+    iconFor(attachment) {
+      const extensions = Vue.prototype.$filesIconsExtension;
+      return extensions[0].get(attachment.mimetype) || extensions[0].get('file');
+    },
+    formatSize(bytes) {
+      if (!bytes) {
+        return '';
+      }
+      const units = ['B', 'KB', 'MB', 'GB'];
+      let value = bytes;
+      let unit = 0;
+      while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+      }
+      return `${value.toFixed(value < 10 && unit > 0 ? 1 : 0)} ${units[unit]}`;
+    },
+    async download(attachment) {
+      if (attachment.downloading) {
+        return;
+      }
+      this.$set(attachment, 'downloading', true);
+      try {
+        const blobUrl = await this.$matrixService.getMediaBlobUrl(attachment.mxcUrl);
+        if (!blobUrl) {
+          this.$root.$emit('alert-message', this.$t('matrix.chat.file.no.available'), 'error');
+          return;
+        }
+        const link = document.createElement('a');
+        link.href = blobUrl;
+        link.download = attachment.name || 'file';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(blobUrl);
+      } finally {
+        this.$set(attachment, 'downloading', false);
+      }
+    },
+    reset() {
+      this.attachments = [];
+      this.room = null;
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomHeaderActions.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomHeaderActions.vue
@@ -111,6 +111,23 @@
             {{ $t('matrix.room.members.label') }}
           </span>
         </v-list-item>
+        <v-list-item
+          class="ps-2 pe-3 height-auto"
+          @click.stop="showAttachments">
+          <v-sheet
+            class="d-flex"
+            width="28"
+            height="36">
+            <v-icon
+              class="icon-default-color mx-auto"
+              size="16">
+              fas fa-paperclip
+            </v-icon>
+          </v-sheet>
+          <span>
+            {{ $t('matrix.room.attachments.label') }}
+          </span>
+        </v-list-item>
       </v-list>
     </v-menu>
   </div>
@@ -217,6 +234,10 @@ export default {
     },
     showMembers() {
       this.$root.$emit('show-room-members', this.space);
+      this.$nextTick(() => this.menu = false);
+    },
+    showAttachments() {
+      this.$root.$emit('show-room-attachments', this.room);
       this.$nextTick(() => this.menu = false);
     }
   }

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -879,6 +879,44 @@ export function loadRoomMessages(roomId, from, to) {
   });
 }
 
+// Attachment message types found in a Matrix room timeline.
+const ATTACHMENT_MSG_TYPES = ['m.file', 'm.image', 'm.video', 'm.audio'];
+
+// Lists the attachments (files, images, audio, video) shared in a room by paging
+// back through its timeline. Returned newest-first.
+export async function loadRoomAttachments(roomId, maxPages = 10) {
+  const attachments = [];
+  const seen = new Set();
+  let from = null;
+  for (let page = 0; page < maxPages; page++) {
+    const resp = await loadRoomMessages(roomId, from);
+    const chunk = resp?.chunk || [];
+    for (const e of chunk) {
+      if (e.type === 'm.room.message'
+          && ATTACHMENT_MSG_TYPES.includes(e.content?.msgtype)
+          && e.content?.url
+          && !seen.has(e.event_id)) {
+        seen.add(e.event_id);
+        attachments.push({
+          eventId: e.event_id,
+          name: e.content.body,
+          msgtype: e.content.msgtype,
+          mimetype: e.content.info?.mimetype,
+          size: e.content.info?.size,
+          sender: e.sender,
+          timestamp: e.origin_server_ts,
+          mxcUrl: e.content.url,
+        });
+      }
+    }
+    if (!resp?.end || resp.end === from || chunk.length === 0) {
+      break;
+    }
+    from = resp.end;
+  }
+  return attachments;
+}
+
 export async function loadMessageReactions(roomId, eventId) {
   const url = `/_matrix/client/v1/rooms/${encodeURIComponent(roomId)}/relations/${encodeURIComponent(eventId)}/m.annotation/m.reaction?limit=100`;
   try {

--- a/webapp/src/main/webapp/vue-apps/matrix/main.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/main.js
@@ -20,6 +20,7 @@ import RoomLastMessage from './components/room/RoomLastMessage.vue';
 import SpaceSettingsAdministration from './components/space-settings/SpaceSettingsAdministration.vue';
 import RoomActionMenu from './components/room/RoomActionMenu.vue';
 import RoomActionMenuDrawer from './components/room/RoomActionMenuDrawer.vue';
+import RoomAttachmentsDrawer from './components/room/RoomAttachmentsDrawer.vue';
 import RoomActionListItems from './components/room/RoomActionListItems.vue';
 import MessageReceiptList from './components/message/receipt/MessageReceiptList.vue';
 import MessageReceipt from './components/message/receipt/MessageReceipt.vue';
@@ -66,6 +67,7 @@ const components = {
   'matrix-chat-space-settings': SpaceSettingsAdministration,
   'matrix-room-action-menu': RoomActionMenu,
   'matrix-room-action-menu-drawer': RoomActionMenuDrawer,
+  'matrix-room-attachments-drawer': RoomAttachmentsDrawer,
   'matrix-room-action-list-items': RoomActionListItems,
   'matrix-message-receipt-list': MessageReceiptList,
   'matrix-message-receipt': MessageReceipt,


### PR DESCRIPTION

## What & why
Adds a quick way to see every file shared in a conversation. From a chat, the
header **⋯ menu** now has an **Attachments** entry (below Members) that opens a
drawer listing the conversation's files — so members don't have to scroll the
whole history to find a document, image or voice message.

## What it does
- **Attachments** item in the conversation header (`RoomHeaderActions`) ⋮ menu,
  shown for every conversation (DMs and spaces).
- Opens a drawer that **lists the conversation's attachments** (images, files,
  audio, video): file-type icon, name, date, size, and a **download** per file.
- Loading and empty states.

## How it works
- `MatrixService.loadRoomAttachments(roomId)` pages the room timeline
  (`/_matrix/client/v3/rooms/{id}/messages`) and collects messages of type
  `m.file / m.image / m.video / m.audio` (newest first).
- `RoomAttachmentsDrawer.vue` renders the list; downloads reuse the existing
  authenticated‑media blob helper (`getMediaBlobUrl`). The drawer opens above the
  chat drawer (z‑index handled on open).
- `RoomHeaderActions.vue` emits `show-room-attachments`; the drawer is mounted
  from `ChatButton` like the other room drawers. i18n keys added to the `_en`
  bundle (Crowdin syncs the rest).

## Scope
**Listing only.** Acting on attachments — **"Save to eXo Documents"** — and
**image thumbnails** are intentionally out of scope and tracked separately.

## Synapse compatibility
Works on both the current Tribe Synapse and newer Synapse: listing uses the
standard timeline API, and download reuses the authenticated endpoint the chat
already relies on. (Note: chat image *previews/avatars* still use legacy media
endpoints and will need an authenticated‑media migration before Tribe upgrades
Synapse — separate, pre‑existing, documented.)

## Testing
- `mvn install -pl webapp` — build green.
- Verified live in a browser: header ⋮ → Attachments lists a conversation's
  files (screenshots, a voice message) with icon/name/date/size and download;
  drawer opens on top.

## Files
- `services`: none (front‑end only).
- `webapp`: `RoomAttachmentsDrawer.vue` (new), `RoomHeaderActions.vue`,
  `ChatButton.vue`, `MatrixService.js`, `main.js`, `matrix_en.properties`.