### PR TITLE
feat: chat conversation filters, favorites (two-way Matrix sync) and mark-as-read

### DIFF
--- a/services/src/main/java/io/meeds/chat/plugin/ChatRoomAclPlugin.java
+++ b/services/src/main/java/io/meeds/chat/plugin/ChatRoomAclPlugin.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.chat.plugin;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.security.Identity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.meeds.chat.model.Room;
+import io.meeds.chat.service.MatrixService;
+import io.meeds.portal.plugin.AclPlugin;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * ACL plugin making chat rooms eligible for the platform Favorites framework
+ * (the same mechanism used by Notes, Activities and AI prompts). It registers
+ * itself into {@link UserACL} so the generic {@code FavoriteService}/
+ * {@code FavoriteRest} can authorize favoriting a chat room: the favorite's
+ * {@code objectId} is the Matrix room id and a user may favorite a room only
+ * when they can access it.
+ */
+@Component
+public class ChatRoomAclPlugin implements AclPlugin {
+
+  /** Favorite object type for chat rooms; the favorite objectId is the Matrix room id. */
+  public static final String OBJECT_TYPE = "chatRoom";
+
+  @Autowired
+  private PortalContainer container;
+
+  @Autowired
+  private MatrixService    matrixService;
+
+  @PostConstruct
+  public void init() {
+    UserACL userACL = container.getComponentInstanceOfType(UserACL.class);
+    userACL.addAclPlugin(this);
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean hasPermission(String objectId, String permissionType, Identity identity) {
+    if (objectId == null || identity == null) {
+      return false;
+    }
+    Room room = matrixService.getById(objectId);
+    return room != null && matrixService.canAccess(room, identity.getUserId());
+  }
+
+}

--- a/services/src/test/java/io/meeds/chat/plugin/ChatRoomAclPluginTest.java
+++ b/services/src/test/java/io/meeds/chat/plugin/ChatRoomAclPluginTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.chat.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.security.Identity;
+
+import io.meeds.chat.model.Room;
+import io.meeds.chat.service.MatrixService;
+
+class ChatRoomAclPluginTest {
+
+  private static final String ROOM_ID = "!room:server";
+
+  @Mock
+  private PortalContainer    container;
+
+  @Mock
+  private MatrixService      matrixService;
+
+  @InjectMocks
+  private ChatRoomAclPlugin  plugin;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void shouldExposeChatRoomObjectType() {
+    assertEquals("chatRoom", ChatRoomAclPlugin.OBJECT_TYPE);
+    assertEquals("chatRoom", plugin.getObjectType());
+  }
+
+  @Test
+  void shouldRegisterItselfIntoUserAclOnInit() {
+    UserACL userACL = org.mockito.Mockito.mock(UserACL.class);
+    when(container.getComponentInstanceOfType(UserACL.class)).thenReturn(userACL);
+
+    plugin.init();
+
+    verify(userACL).addAclPlugin(plugin);
+  }
+
+  @Test
+  void shouldDenyWhenObjectIdIsNull() {
+    assertFalse(plugin.hasPermission(null, "VIEW", new Identity("john")));
+    verify(matrixService, never()).getById(anyString());
+  }
+
+  @Test
+  void shouldDenyWhenIdentityIsNull() {
+    assertFalse(plugin.hasPermission(ROOM_ID, "VIEW", null));
+    verify(matrixService, never()).getById(anyString());
+  }
+
+  @Test
+  void shouldDenyWhenRoomDoesNotExist() {
+    when(matrixService.getById(ROOM_ID)).thenReturn(null);
+
+    assertFalse(plugin.hasPermission(ROOM_ID, "VIEW", new Identity("john")));
+  }
+
+  @Test
+  void shouldDenyWhenUserCannotAccessRoom() {
+    Room room = new Room();
+    room.setRoomId(ROOM_ID);
+    when(matrixService.getById(ROOM_ID)).thenReturn(room);
+    when(matrixService.canAccess(room, "john")).thenReturn(false);
+
+    assertFalse(plugin.hasPermission(ROOM_ID, "VIEW", new Identity("john")));
+  }
+
+  @Test
+  void shouldAllowWhenUserCanAccessRoom() {
+    Room room = new Room();
+    room.setRoomId(ROOM_ID);
+    when(matrixService.getById(ROOM_ID)).thenReturn(room);
+    when(matrixService.canAccess(any(Room.class), anyString())).thenReturn(true);
+
+    assertTrue(plugin.hasPermission(ROOM_ID, "VIEW", new Identity("john")));
+  }
+
+}

--- a/webapp/src/main/resources/locale/portlet/matrix_en.properties
+++ b/webapp/src/main/resources/locale/portlet/matrix_en.properties
@@ -62,6 +62,15 @@ matrix.room.mute.label=Mute
 matrix.room.unmute.label=Unmute
 matrix.room.mute.success=Chat room has been muted
 matrix.room.unmute.success=Chat room has been unmuted
+matrix.room.favorite.add.label=Add to favorites
+matrix.room.favorite.remove.label=Remove from favorites
+matrix.room.favorite.add.success=Conversation added to favorites
+matrix.room.favorite.remove.success=Conversation removed from favorites
+matrix.room.favorite.error=The favorite could not be updated
+matrix.room.markRead.label=Mark as read
+matrix.room.markRead.success=Conversation marked as read
+matrix.chat.markAllRead.label=Mark all as read
+matrix.chat.markAllRead.success=All conversations marked as read
 
 
 matrix.message.view.label=View
@@ -82,6 +91,14 @@ matrix.messages.jump.to.last=Jump to the last message
 matrix.messages.check.new=Check new messages
 
 matrix.rooms.filter.placeholder=Filter by name
+matrix.rooms.filter.favorite=Favorites
+matrix.rooms.filter.conversations=1:1
+matrix.rooms.filter.spaces=Spaces
+matrix.rooms.filter.unread=Unread
+matrix.favorite.typeLabel=Chat
+matrix.favorite.subtitle=Conversation
+matrix.favorite.removed=Conversation removed from favorites
+matrix.favorite.removeError=The favorite could not be removed
 matrix.chat.upload.audio.size.exceed=Audio file is too large. Maximum allowed size: {0}
 matrix.chat.label.cancelRecording=Cancel recording
 matrix.unread.section.load.exceed=We cannot automatically load the top of unread section

--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -85,6 +85,26 @@
   </portlet>
 
   <module>
+    <name>MatrixFavoriteDrawerExtension</name>
+    <load-group>FavoriteDrawerGRP</load-group>
+    <script>
+      <path>/js/matrixFavoritesExtension.bundle.js</path>
+    </script>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
+  <module>
     <name>MatrixChatNotificationExtension</name>
     <load-group>notificationGRP</load-group>
     <script>

--- a/webapp/src/main/webapp/vue-apps/matrix-favorites-extension/components/ChatRoomFavoriteItem.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix-favorites-extension/components/ChatRoomFavoriteItem.vue
@@ -1,0 +1,117 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2025 Meeds Association contact@meeds.io
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-list-item
+    v-if="roomName"
+    @click="open">
+    <v-list-item-icon class="me-3 my-auto">
+      <v-card
+        :min-width="iconWidth"
+        class="d-flex justify-center no-border-radius"
+        color="transparent"
+        flat>
+        <v-icon :size="iconSize">fa-comments</v-icon>
+      </v-card>
+    </v-list-item-icon>
+    <v-list-item-content>
+      <v-list-item-title class="text-truncate text-color">
+        {{ roomName }}
+      </v-list-item-title>
+      <v-list-item-subtitle
+        v-if="expanded"
+        class="d-flex align-center full-width overflow-hidden pt-2px">
+        <v-icon class="me-1" size="12">fa-comments</v-icon>
+        {{ $t('matrix.favorite.subtitle') }}
+      </v-list-item-subtitle>
+    </v-list-item-content>
+    <v-list-item-action>
+      <favorite-button
+        :id="id"
+        :favorite="isFavorite"
+        :type-label="$t('matrix.favorite.typeLabel')"
+        type="chatRoom"
+        @removed="removed"
+        @remove-error="removeError" />
+    </v-list-item-action>
+  </v-list-item>
+</template>
+<script>
+export default {
+  props: {
+    id: {
+      type: String,
+      default: null,
+    },
+    clickCallback: {
+      type: Function,
+      default: null,
+    },
+    expanded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data: () => ({
+    isFavorite: true,
+    room: null,
+  }),
+  computed: {
+    iconWidth() {
+      return this.expanded ? 40 : 30;
+    },
+    iconSize() {
+      return this.expanded ? 34 : 24;
+    },
+    roomName() {
+      return this.room?.name || '';
+    },
+  },
+  async created() {
+    if (!this.id) {
+      return;
+    }
+    // Reuse the chat's cached rooms so DMs and space rooms get their proper title.
+    try {
+      const cached = await this.$matrixService.retrieveCachedRooms();
+      const rooms = cached ? JSON.parse(cached) : [];
+      this.room = rooms.find(room => room.id === this.id) || null;
+    } catch {
+      this.room = null;
+    }
+  },
+  methods: {
+    open() {
+      if (this.clickCallback) {
+        this.clickCallback('chatRoom', this.id);
+      }
+      // The chat button lives in the top navigation on every page; ask it to open the room.
+      document.dispatchEvent(new CustomEvent(this.$chatConstants.ACTION_OPEN_CHAT_ROOM, {
+        detail: {room: this.room}
+      }));
+    },
+    removed() {
+      this.isFavorite = false;
+      this.$root.$emit('alert-message', this.$t('matrix.favorite.removed'), 'success');
+      this.$emit('removed');
+      this.$root.$emit('refresh-favorite-list');
+    },
+    removeError() {
+      this.$root.$emit('alert-message', this.$t('matrix.favorite.removeError'), 'error');
+    },
+  },
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/matrix-favorites-extension/main.js
+++ b/webapp/src/main/webapp/vue-apps/matrix-favorites-extension/main.js
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import * as matrixService from '../matrix/js/MatrixService.js';
+import { chatConstants } from '../matrix/js/Constants.js';
+import ChatRoomFavoriteItem from './components/ChatRoomFavoriteItem.vue';
+
+// This bundle loads site-wide (top-bar Favorites drawer), where the chat portlet's
+// main.js has not run, so wire the services the favorite item needs ourselves.
+if (!Vue.prototype.$matrixService) {
+  window.Object.defineProperty(Vue.prototype, '$matrixService', { value: matrixService });
+}
+if (!Vue.prototype.$chatConstants) {
+  window.Object.defineProperty(Vue.prototype, '$chatConstants', { value: chatConstants });
+}
+
+Vue.component('chat-room-favorite-item', ChatRoomFavoriteItem);
+
+extensionRegistry.registerExtension('favorite', 'favorite-type', {
+  rank: 70,
+  id: 'chatRoom',
+  name: 'Chat',
+  icon: 'fa-comments',
+});
+
+extensionRegistry.registerComponent('favorite-chatRoom', 'favorite-drawer-item', {
+  id: 'chatRoom',
+  vueComponent: Vue.options.components['chat-room-favorite-item'],
+});

--- a/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
@@ -87,6 +87,7 @@ export default {
     targetRoomId: null,
     searchTimer: null,
     searchTerm: null,
+    activeFilters: [],
     activeRoomId: null,
     cacheRoomsTimeout: null,
     cacheRoomsLock: false,
@@ -137,6 +138,9 @@ export default {
     this.$root.$on('chat-event-total-unread-updated', this.handleTotalUnreadUpdate);
     this.$root.$on('message-sent-statistics', this.sendMessageStatistics);
     this.$root.$on('room-muted-updated', this.handleRoomMuteUpdate);
+    this.$root.$on('room-favorite-updated', this.handleRoomFavoriteUpdate);
+    this.$root.$on('chat-rooms-filter-changed', this.handleRoomsFilterChanged);
+    this.$root.$on('chat-mark-all-read', this.markAllRoomsRead);
     this.$root.$on('show-room-members', this.showRoomMembers);
     document.addEventListener('matrix-message-received', this.enqueueMessageReceivedEvent);
     document.addEventListener('matrix-message-reaction-added', this.reactionReceived);
@@ -164,6 +168,9 @@ export default {
     this.$root.$off('chat-event-total-unread-updated',this.handleTotalUnreadUpdate);
     this.$root.$off('message-sent-statistics', this.sendMessageStatistics);
     this.$root.$off('room-muted-updated', this.handleRoomMuteUpdate);
+    this.$root.$off('room-favorite-updated', this.handleRoomFavoriteUpdate);
+    this.$root.$off('chat-rooms-filter-changed', this.handleRoomsFilterChanged);
+    this.$root.$off('chat-mark-all-read', this.markAllRoomsRead);
     this.$root.$off('show-room-members', this.showRoomMembers);
     document.removeEventListener('matrix-message-received', this.enqueueMessageReceivedEvent);
     document.removeEventListener('matrix-message-deleted', this.messageDeleted);
@@ -200,15 +207,20 @@ export default {
       return this.presence === 'available';
     },
     filteredRooms() {
+      let rooms = this.rooms || [];
+      // Chip filters are OR-ed within themselves and AND-ed with the text filter.
+      if (this.activeFilters?.length) {
+        rooms = rooms.filter(room => this.activeFilters.some(filter => this.matchesFilter(room, filter)));
+      }
       if (!this.searchTerm) {
-        return this.rooms;
+        return rooms;
       }
       const normalize = str =>
         str?.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase() || '';
 
       const normalizedSearch = normalize(this.searchTerm);
 
-      return this.rooms.filter(room =>
+      return rooms.filter(room =>
         normalize(room.name).includes(normalizedSearch)
       );
     },
@@ -588,6 +600,12 @@ export default {
         const loadedRooms = matrixRoomsObject.rooms || [];
         this.rooms = this.mergeRoomsWithCache(loadedRooms, this.rooms);
         this.$root.$emit('chat-event-total-unread-updated', matrixRoomsObject.totalUnreadMessages);
+        // Mirror the Matrix m.favourite tags into the Meeds Favorites framework so
+        // favorites set from a third-party Matrix client (Element) also appear in the
+        // platform's global Favorites drawer. Best-effort, never blocks the room list.
+        const favoriteRoomIds = (this.rooms || []).filter(room => room.favorite).map(room => room.id);
+        this.$matrixService.reconcileMeedsFavorites(favoriteRoomIds)
+          .catch(e => console.error('Favorite reconciliation failed:', e));
       })
         .finally(() => {
           this.loading = false;
@@ -691,6 +709,46 @@ export default {
       if (wasMuted !== room.muted) {
         const delta = updatedRoom.unreadMessages || 0;
         this.updateTotalUnread(delta, room.muted, true);
+      }
+    },
+    handleRoomFavoriteUpdate(payload) {
+      const updatedRoom = this.getLocalRoomById(payload?.roomId);
+      if (updatedRoom) {
+        updatedRoom.favorite = payload.favorite;
+      }
+    },
+    handleRoomsFilterChanged(filters) {
+      this.activeFilters = filters || [];
+    },
+    markAllRoomsRead() {
+      const unreadRooms = (this.rooms || []).filter(room => (room.unreadMessages || 0) > 0);
+      if (!unreadRooms.length) {
+        return;
+      }
+      Promise.all(unreadRooms.map(room =>
+        this.$matrixService.getRoomLastMessageEventId(room.id).then(eventId =>
+          eventId && this.$matrixService.markRoomAsFullyRead(room.id, eventId).then(() => {
+            document.dispatchEvent(new CustomEvent('matrix-room-mark-full-read', {
+              detail: {roomId: room.id}
+            }));
+          })
+        ).catch(e => console.error('Failed to mark room as read:', room.id, e))
+      )).then(() => {
+        this.$root.$emit('alert-message', this.$t('matrix.chat.markAllRead.success'), 'success');
+      });
+    },
+    matchesFilter(room, filter) {
+      switch (filter) {
+      case 'favorite':
+        return !!room.favorite;
+      case 'dm':
+        return !!room.directChat;
+      case 'space':
+        return !!room.spaceId;
+      case 'unread':
+        return (room.unreadMessages || 0) > 0;
+      default:
+        return true;
       }
     },
     handleSpaceMute({detail: {spaceId}}) {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatBody.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatBody.vue
@@ -28,6 +28,7 @@
         'background-grey-primary ': fullPageMode
       }"
       class="fill-height overflow-y-auto flex-shrink-1 flex-grow-1 overflow-x-hidden specific-scrollbar">
+      <matrix-room-filter-chips />
       <matrix-chat-rooms
         :rooms="rooms"
         :selected-room="selectedRoom"

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
@@ -53,6 +53,18 @@
           </v-btn>
           <v-btn
             v-if="fullPageMode"
+            :title="$t('matrix.chat.markAllRead.label')"
+            :disabled="!hasUnread"
+            icon
+            @click="markAllAsRead">
+            <v-icon
+              class="icon-default-color"
+              size="20">
+              fa-envelope-open-text
+            </v-icon>
+          </v-btn>
+          <v-btn
+            v-if="fullPageMode"
             icon
             @click="openFilter">
             <v-icon
@@ -78,6 +90,18 @@
           class="icon-default-color"
           size="20">
           fa-plus
+        </v-icon>
+      </v-btn>
+      <v-btn
+        v-if="!fullPageMode && !selectedRoom"
+        :title="$t('matrix.chat.markAllRead.label')"
+        :disabled="!hasUnread"
+        icon
+        @click="markAllAsRead">
+        <v-icon
+          class="icon-default-color"
+          size="20">
+          fa-envelope-open-text
         </v-icon>
       </v-btn>
       <div 
@@ -148,6 +172,9 @@ export default {
     },
     defaultRoomListContainerWidth() {
       return this.$root.defaultRoomListContainerWidth;
+    },
+    hasUnread() {
+      return (this.rooms || []).some(room => (room.unreadMessages || 0) > 0);
     }
   },
   watch: {
@@ -221,6 +248,9 @@ export default {
     },
     openQuickCreateChatDiscussionDrawer() {
       this.$root.$emit(this.$chatConstants.ACTION_CHAT_OPEN_QUICK_CREATE_DISCUSSION_DRAWER);
+    },
+    markAllAsRead() {
+      this.$root.$emit('chat-mark-all-read');
     },
   },
 };

--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomActionListItems.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomActionListItems.vue
@@ -21,6 +21,26 @@
   <v-list class="pa-0">
     <v-list-item
       class="ps-2 pe-3 height-auto"
+      @click.stop="toggleFavorite">
+      <v-sheet
+        class="d-flex"
+        width="28"
+        height="36">
+        <v-icon
+          class="icon-default-color mx-auto"
+          size="16">
+          {{ isFavorite ? 'fas fa-star' : 'far fa-star' }}
+        </v-icon>
+      </v-sheet>
+      <span v-if="!isFavorite">
+        {{ $t('matrix.room.favorite.add.label') }}
+      </span>
+      <span v-else>
+        {{ $t('matrix.room.favorite.remove.label') }}
+      </span>
+    </v-list-item>
+    <v-list-item
+      class="ps-2 pe-3 height-auto"
       @click.stop="muteRoom">
       <v-sheet
         class="d-flex"
@@ -39,6 +59,24 @@
         {{ $t('matrix.room.unmute.label') }}
       </span>
     </v-list-item>
+    <v-list-item
+      class="ps-2 pe-3 height-auto"
+      :disabled="!hasUnread"
+      @click.stop="markAsRead">
+      <v-sheet
+        class="d-flex"
+        width="28"
+        height="36">
+        <v-icon
+          class="icon-default-color mx-auto"
+          size="16">
+          fa-envelope-open-text
+        </v-icon>
+      </v-sheet>
+      <span>
+        {{ $t('matrix.room.markRead.label') }}
+      </span>
+    </v-list-item>
   </v-list>
 </template>
 
@@ -55,11 +93,51 @@ export default {
     isMuted() {
       return this.room?.muted;
     },
+    isFavorite() {
+      return this.room?.favorite;
+    },
+    hasUnread() {
+      return (this.room?.unreadMessages || 0) > 0;
+    },
     spaceId() {
       return this.room?.spaceId;
     },
   },
   methods: {
+    toggleFavorite() {
+      const willBeFavorite = !this.isFavorite;
+      const request = willBeFavorite
+        ? this.$matrixService.favoriteRoom(this.room.id, this.spaceId)
+        : this.$matrixService.unfavoriteRoom(this.room.id);
+      request.then(() => {
+        // Optimistically reflect the new state so the favorite filter reacts immediately.
+        this.$set(this.room, 'favorite', willBeFavorite);
+        this.$root.$emit('alert-message',
+          this.$t(`matrix.room.favorite.${willBeFavorite ? 'add' : 'remove'}.success`),
+          'success');
+        this.$emit('close');
+        this.$root.$emit('room-favorite-updated', {
+          roomId: this.room.id,
+          favorite: willBeFavorite
+        });
+      }).catch(() => {
+        this.$root.$emit('alert-message', this.$t('matrix.room.favorite.error'), 'error');
+      });
+    },
+    markAsRead() {
+      this.$emit('close');
+      this.$matrixService.getRoomLastMessageEventId(this.room.id).then(eventId => {
+        if (!eventId) {
+          return;
+        }
+        this.$matrixService.markRoomAsFullyRead(this.room.id, eventId).then(() => {
+          document.dispatchEvent(new CustomEvent('matrix-room-mark-full-read', {
+            detail: {roomId: this.room.id}
+          }));
+          this.$root.$emit('alert-message', this.$t('matrix.room.markRead.success'), 'success');
+        });
+      });
+    },
     muteRoom() {
       this.$matrixService.muteRoom(this.room.id, this.spaceId, this.isMuted).then(() => {
         this.$root.$emit('alert-message',

--- a/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomFilterChips.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/room/RoomFilterChips.vue
@@ -1,0 +1,56 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2025 Meeds Association contact@meeds.io
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+
+<template>
+  <v-chip-group
+    v-model="selected"
+    multiple
+    column
+    class="px-4 py-1"
+    @change="emitChange">
+    <v-chip
+      v-for="filter in filters"
+      :key="filter.key"
+      :value="filter.key"
+      filter
+      outlined
+      small>
+      {{ $t(filter.label) }}
+    </v-chip>
+  </v-chip-group>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      selected: [],
+      filters: [
+        { key: 'favorite', label: 'matrix.rooms.filter.favorite' },
+        { key: 'unread', label: 'matrix.rooms.filter.unread' },
+        { key: 'dm', label: 'matrix.rooms.filter.conversations' },
+        { key: 'space', label: 'matrix.rooms.filter.spaces' },
+      ],
+    };
+  },
+  methods: {
+    emitChange() {
+      this.$root.$emit('chat-rooms-filter-changed', this.selected);
+    }
+  }
+};
+</script>

--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -459,11 +459,14 @@ export function toRoomObject(rooms, currentMemberId) {
     const roomData = rooms[roomId];
     const events = [...roomData.timeline.events, ...roomData.state.events];
     const notificationCount = roomData.unread_notifications.notification_count;
+    // Matrix-native favorite: the `m.favourite` room tag (also set by Element & co.)
+    const tagEvent = (roomData.account_data?.events || []).find(e => e.type === 'm.tag');
+    const isFavorite = !!tagEvent?.content?.tags?.['m.favourite'];
     const roomItem = {
       id: roomId,
       enabledUser: true,
       external: false,
-      favorite: false,
+      favorite: isFavorite,
       unreadMessages: notificationCount,
       members: [],
     };
@@ -1801,6 +1804,99 @@ export async function muteRoom(roomId, spaceId, isMuted) {
     console.error('Error muting private room:', error);
     throw error;
   }
+}
+
+// Favorites are kept in sync two ways:
+//  - Matrix-native: the `m.favourite` room tag, so third-party clients (Element,
+//    Element X) see/filter the same favorites and a favorite set there flows back
+//    into the chat list (read in toRoomObject from the /sync account_data m.tag).
+//  - Meeds Favorites framework (generic /v1/social/favorites REST), so chat rooms
+//    appear in the platform Favorites drawer alongside notes, AI prompts, etc.
+// The Matrix tag is the source of truth for the chat UI; objectId is the room id.
+export const FAVORITE_OBJECT_TYPE = 'chatRoom';
+
+function favoritesBaseUrl() {
+  return `${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/social/favorites`;
+}
+
+function matrixFavoriteTagUrl(roomId) {
+  const matrixUserId = localStorage.getItem('matrix_user_id');
+  return `/_matrix/client/v3/user/${encodeURIComponent(matrixUserId)}/rooms/${encodeURIComponent(roomId)}/tags/m.favourite`;
+}
+
+async function setMatrixFavoriteTag(roomId, favorite) {
+  const options = {
+    method: favorite ? 'PUT' : 'DELETE',
+    headers: {
+      'Authorization': `Bearer ${localStorage.getItem('matrix_access_token')}`,
+      'Content-Type': 'application/json',
+    },
+  };
+  if (favorite) {
+    options.body = JSON.stringify({order: 0.5});
+  }
+  const response = await fetch(matrixFavoriteTagUrl(roomId), options);
+  if (!response?.ok) {
+    throw new Error('Error updating the Matrix favorite tag');
+  }
+}
+
+function setMeedsFavorite(roomId, spaceId, favorite) {
+  const url = favorite
+    ? `${favoritesBaseUrl()}/${FAVORITE_OBJECT_TYPE}/${encodeURIComponent(roomId)}${spaceId ? `?parentObjectId=${encodeURIComponent(spaceId)}` : ''}`
+    : `${favoritesBaseUrl()}/${FAVORITE_OBJECT_TYPE}/${encodeURIComponent(roomId)}?ignoreNotExisting=true`;
+  return fetch(url, {
+    method: favorite ? 'POST' : 'DELETE',
+    credentials: 'include',
+  });
+}
+
+export async function favoriteRoom(roomId, spaceId) {
+  // Matrix tag drives the chat UI and third-party clients; fail hard if it fails.
+  await setMatrixFavoriteTag(roomId, true);
+  // Meeds favorite powers the global Favorites drawer; best-effort, don't block the UI.
+  await setMeedsFavorite(roomId, spaceId, true).catch(e => console.error('Meeds favorite sync failed:', e));
+  return true;
+}
+
+export async function unfavoriteRoom(roomId) {
+  await setMatrixFavoriteTag(roomId, false);
+  await setMeedsFavorite(roomId, null, false).catch(e => console.error('Meeds favorite sync failed:', e));
+  return true;
+}
+
+// Returns the room ids currently favorited in the Meeds Favorites framework.
+async function getMeedsFavoriteRoomIds() {
+  const url = `${favoritesBaseUrl()}?type=${FAVORITE_OBJECT_TYPE}&returnSize=true&offset=0&limit=500`;
+  const response = await fetch(url, {method: 'GET', credentials: 'include'});
+  if (!response?.ok) {
+    return [];
+  }
+  const data = await response.json();
+  return (data?.favoritesItem || []).map(item => item.objectId);
+}
+
+/**
+ * Reconciles the Meeds Favorites (which power the global Favorites drawer) with the
+ * Matrix `m.favourite` tags (the source of truth, shared with Element & co.).
+ * This is what makes a favorite set from a third-party Matrix client show up in the
+ * platform Favorites drawer — and a favorite removed there disappear from it.
+ *
+ * @param favoriteRoomIds room ids tagged m.favourite (from the sync), as read into the room list
+ */
+export async function reconcileMeedsFavorites(favoriteRoomIds) {
+  const tagSet = new Set(favoriteRoomIds || []);
+  const meedsIds = await getMeedsFavoriteRoomIds();
+  const meedsSet = new Set(meedsIds);
+  const toAdd = [...tagSet].filter(id => !meedsSet.has(id));
+  const toRemove = meedsIds.filter(id => !tagSet.has(id));
+  if (!toAdd.length && !toRemove.length) {
+    return;
+  }
+  await Promise.all([
+    ...toAdd.map(id => setMeedsFavorite(id, null, true)),
+    ...toRemove.map(id => setMeedsFavorite(id, null, false)),
+  ]);
 }
 
 export async function sendTyping(roomId, isTyping, timeoutMs = 30000) {

--- a/webapp/src/main/webapp/vue-apps/matrix/main.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/main.js
@@ -32,6 +32,7 @@ import RoomAvatar from './components/room/RoomAvatar.vue';
 import RoomHeaderActions from './components/room/RoomHeaderActions.vue';
 import MatrixChatBody from './components/MatrixChatBody.vue';
 import FilterRoomListInput from './components/room/FilterRoomListInput.vue';
+import RoomFilterChips from './components/room/RoomFilterChips.vue';
 import ChatHeaderUserAvatar from './components/ChatHeaderUserAvatar.vue';
 import FileMessage from './components/message/FileMessage.vue';
 
@@ -78,6 +79,7 @@ const components = {
   'matrix-room-header-actions': RoomHeaderActions,
   'matrix-chat-body': MatrixChatBody,
   'matrix-filter-room-list-input': FilterRoomListInput,
+  'matrix-room-filter-chips': RoomFilterChips,
   'matrix-chat-header-user-avatar': ChatHeaderUserAvatar,
   'matrix-file-message': FileMessage,
 };

--- a/webapp/webpack.prod.js
+++ b/webapp/webpack.prod.js
@@ -38,6 +38,7 @@ const config = {
     matrixChatNotificationsExtension: './src/main/webapp/vue-apps/notification/main.js',
     analyticsExtensionMatrix: './src/main/webapp/vue-apps/analytics-extension/main.js',
     userSettingsNotificationsExtension: './src/main/webapp/vue-apps/user-settings-notifications-extension/main.js',
+    matrixFavoritesExtension: './src/main/webapp/vue-apps/matrix-favorites-extension/main.js',
   },
   output: {
     path: path.join(__dirname, 'target/matrix/'),


### PR DESCRIPTION
## What & why

Usability improvements to the chat portlet so members can find and tidy their
conversations faster. No new app to learn — everything lives inside the existing
chat and the platform's Favorites drawer.

## Features

### 1. Conversation filter chips
A multi-select chip bar above the conversation list: **Favorite · Unread · 1:1 · Spaces**,
AND-ed with the existing search-by-name box. Client-side predicates over the loaded rooms.

### 2. Favorites (two-way sync with Matrix)
- Favorite a conversation from the row **⋯ menu** (next to Mute) — no star added to the row itself.
- Favorites are kept in sync **both ways** with the Matrix **`m.favourite`** room tag, so a
  favorite set here is visible/filterable in third-party Matrix clients (**Element / Element X**),
  and a favorite set there flows back into the chat list (read from the `/sync` `m.tag`).
- Favorited chats also appear in the platform's **global Favorites drawer** under a new **Chat**
  `matrix-favorites-extension` bundle. A favorite created only in Element is reconciled into
  the Meeds Favorites framework on chat load.

### 3. Mark as read
- **Per conversation**: a "Mark as read" action in the ⋯ menu.
- **Global**: a "Mark all as read" button in the chat drawer header.
- Both use the platform's standard `fa-envelope-open-text` icon and **grey out when nothing
  is unread** (consistent with the notifications drawer).

## Implementation notes
- Backend: `io.meeds.chat.plugin.ChatRoomAclPlugin` (object type `chatRoom`) — no custom REST,
  DAO or schema; favorites reuse the generic `/v1/social/favorites` framework.
- Front-end: new `RoomFilterChips.vue`, `matrix-favorites-extension` (drawer item + registration,
  loaded via `gatein-resources` `FavoriteDrawerGRP`), favorite/read logic in `MatrixService.js`
  and `ChatButton.vue`. i18n keys added to the `_en` bundle (Crowdin syncs the rest).

## Testing
- `mvn install -pl services` green — JaCoCo 0.63 gate passes; 7 new `ChatRoomAclPlugin` unit tests.
- webpack production build clean.
- Rebased onto and **verified end-to-end live on 7.3** in the browser: filter chips render and
  filter correctly (Spaces, Favorites AND-ed), favorite ⋮ action ("Remove from favorites"),
  the favorited room appears in the **global Favorites drawer** (Chat category) and opens on
  click, `m.favourite` tag reflected from Matrix, and **Mark as read greys out when nothing
  is unread**.

## Follow-ups (not in this PR)
- Favorite / mark-as-read from inside an open conversation (header currently only offers Mute).
- Live mid-session sync of favorite/read state from Element.
- Optional true server-side reconciliation job for users who never open the web chat.

## References
- Functional overview & test report: https://community.exoplatform.com/portal/s/273/notes/46613
- Task board: https://community.exoplatform.com/portal/dw/tasks/projectDetail/8331

> Note: supersedes PR #525, which GitHub closed when its branch `feat/chatroom-v1` was renamed
> to `feat/chat-filters-favorites-read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
