### PR TITLE
fix: Escape HTML entities in plain text chat messages - EXO-87198

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/js/MatrixService.js
@@ -1111,7 +1111,7 @@ export async function formatMessage(message, room) {
   const replacements = await Promise.all(
     mentions.map(async ([fullMatch, matrixId, displayName]) => {
       let matrixIdWithoutSpecialChar = matrixId.substring(1).replaceAll('@', '-');
-      matrixIdWithoutSpecialChar = '@' + matrixIdWithoutSpecialChar;
+      matrixIdWithoutSpecialChar = `@${  matrixIdWithoutSpecialChar}`;
       const user = await getUserByMatrixId(matrixIdWithoutSpecialChar, room);
       const userId = user?.remoteId;
       if (!userId) {
@@ -1272,7 +1272,10 @@ export async function processMediaExistence(item) {
 export async function processMessageMentions(item, room) {
   const rawMessage =
         (item.content.format === 'org.matrix.custom.html' && item.content.formatted_body) ||
-        item.content.body?.replace(/\n/g, '<br />') || '';
+      item.content.body?.replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('\n', '<br />') || '';
 
   if (!rawMessage) {
     return;


### PR DESCRIPTION
prior to this change, messages starting with `<` (e.g. `<hello`) were silently dropped from the conversation because the plain text body was injected into an HTML context unescaped, causing the sanitizer to treat it as a malformed tag and strip it.

This PR escapes `&`, `<`, and `>` in plain text bodies before HTML rendering. Formatted messages (`org.matrix.custom.html`) are unaffected.
