### PR TITLE
feat: conditions for adding space/private rooms from Chat - Meeds-io/Mips#249 - MEED-10487

### DIFF
--- a/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/ChatButton.vue
@@ -90,9 +90,7 @@ export default {
     activeRoomId: null,
     cacheRoomsTimeout: null,
     cacheRoomsLock: false,
-    pendingCache: false,
-    spaceCircleTemplate: null,
-    isSubspaceTemplate: null
+    pendingCache: false
   }),
   created() {
     this.tryBecomePresencePollingOwner();
@@ -160,7 +158,6 @@ export default {
     }
     this.$nextTick().then(() => {
       this.$matrixService.registerUserToken();
-      this.isCircleTemplateEnabled();
     });
   },
   beforeDestroy() {
@@ -466,7 +463,6 @@ export default {
     },
     openDrawer() {
       this.open = true;
-      this.isCircleTemplateEnabled();
       this.$refs.meedsChatDrawer?.open();
     },
     async handleMessageReceivedEvent(event) {
@@ -753,15 +749,6 @@ export default {
         });
       }
     },
-    async isCircleTemplateEnabled() {
-      const templates = await this.$spaceTemplateService.getSpaceTemplates(false);
-      const circleTemplate = templates?.find(template => template.system && template.layout === 'circle' && !template.deleted);
-      this.$root.spaceCircleTemplate = circleTemplate || null;
-      if (circleTemplate) {
-        const subspaceTemplateIds = await this.$spaceTemplateService.getSubspaceTemplateIds() || [];
-        this.$root.isSubspaceTemplate = subspaceTemplateIds.includes(circleTemplate.id);
-      }
-    }
   }
 };
 </script>

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatDrawer.vue
@@ -114,8 +114,7 @@ export default {
       expanded: false,
       selectedRoom: null,
       componentKey: 0,
-      previousRoomId: null,
-      canCreateRooms: true
+      previousRoomId: null
     };
   },
   props: {
@@ -149,6 +148,9 @@ export default {
     },
     defaultRoomListContainerWidth() {
       return this.$root.defaultRoomListContainerWidth;
+    },
+    canCreateRooms() {
+      return this.$root.canCreateRooms;
     }
   },
   watch: {
@@ -216,7 +218,6 @@ export default {
       }
     },
     open() {
-      this.canCreateRooms = (!!this.$root.spaceCircleTemplate && meedsChat.spaceRoomsEnabled) || meedsChat.privateRoomsEnabled;
       if (!this.$refs.meedsChatDrawer.drawer) {
         this.$refs.meedsChatDrawer.open();
       }

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MatrixChatRooms.vue
@@ -102,7 +102,9 @@ export default {
       } else if (this.rooms[roomExistsIndex]) {
         this.rooms[roomExistsIndex].name = event.detail.name || this.rooms[roomExistsIndex].name;
         this.rooms[roomExistsIndex].avatarUrl = event.detail.avatarUrl || this.rooms[roomExistsIndex].avatarUrl;
-        this.rooms[roomExistsIndex].members.unshift(event.detail.members);
+        if (!this.rooms[roomExistsIndex].directChat) {
+          this.rooms[roomExistsIndex].members?.unshift(event.detail.members);
+        }
       }
     },
     onIntersect(entries) {

--- a/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatQuickCreateDiscussionDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/matrix/components/MeedsChatQuickCreateDiscussionDrawer.vue
@@ -66,7 +66,7 @@
                 {{ $t('matrix.chat.quick.create.space.room.disabled') }}.
               </span>
             </div>
-            <div 
+            <div
               v-else-if="shouldJoinParentSpace">
               <span class="text-subtitle ps-1">
                 <v-icon small>info</v-icon>
@@ -135,16 +135,16 @@ export default {
   },
   computed: {
     canCreateSpaceRooms() {
-      return !!this.$root.spaceCircleTemplate && meedsChat.spaceRoomsEnabled;
-    },
-    canSelectParentSpace() {
-      return this.invitedSpaceMembers && this.isSubspaceTemplate && this.parentSpaceList.length > 0;
-    },
-    shouldJoinParentSpace() {
-      return this.invitedSpaceMembers && this.isSubspaceTemplate && this.parentSpaceList.length === 0;
+      return this.$root.canCreateSpaceRooms;
     },
     canCreatePrivateRooms() {
-      return meedsChat.privateRoomsEnabled;
+      return this.$root.canCreatePrivateRooms;
+    },
+    canSelectParentSpace() {
+      return this.invitedSpaceMembers && this.$root.isSubspaceTemplate && this.parentSpaceList.length > 0;
+    },
+    shouldJoinParentSpace() {
+      return this.invitedSpaceMembers && this.$root.isSubspaceTemplate && this.parentSpaceList.length === 0;
     },
     hasMoreParentSpaces() {
       return this.parentSpaceList.length < this.parentSpacesSize;
@@ -158,7 +158,7 @@ export default {
       };
     },
     disabledSaveButton(){
-      return !this.participant || (this.participant.length <= 1 && !meedsChat.privateRoomsEnabled) || this.shouldJoinParentSpace || this.canSelectParentSpace && !this.selectedSpace;
+      return !this.participant || (this.participant.length <= 1 && !this.canCreatePrivateRooms) || this.shouldJoinParentSpace || this.canSelectParentSpace && !this.selectedSpace;
     },
   },
   created() {
@@ -167,6 +167,7 @@ export default {
   beforeDestroy() {
     this.$root.$off(this.$chatConstants.ACTION_CHAT_OPEN_QUICK_CREATE_DISCUSSION_DRAWER, this.openDrawer);
   },
+
   methods: {
     openDrawer() {
       this.getParentSpaces().then(() => {

--- a/webapp/src/main/webapp/vue-apps/matrix/main.js
+++ b/webapp/src/main/webapp/vue-apps/matrix/main.js
@@ -123,6 +123,8 @@ export function init(serverName) {
           fullPageMode: false,
           fullPageMessagesContainerWidth: 420,
           defaultRoomListContainerWidth: 404,
+          spaceCircleTemplate: null,
+          isSubspaceTemplate: false,
           statusMap: {
             available: '#2eb58c',
             donotdisturb: '#bc4343',
@@ -134,6 +136,33 @@ export function init(serverName) {
       computed: {
         isMobile() {
           return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
+        },
+        canCreateSpaceRooms() {
+          return !!this.spaceCircleTemplate && meedsChat.spaceRoomsEnabled;
+        },
+        canCreatePrivateRooms() {
+          return meedsChat.privateRoomsEnabled;
+        },
+        canCreateRooms() {
+          return this.canCreateSpaceRooms || this.canCreatePrivateRooms;
+        },
+      },
+      created() {
+        this.checkCanCreateSpaceRooms();
+      },
+      methods: {
+        async checkCanCreateSpaceRooms() {
+          const templates = await this.$spaceTemplateService.getSpaceTemplates(false);
+          const circleTemplate = templates?.find(template => template.system && template.layout === 'circle' && !template.deleted);
+          this.spaceCircleTemplate = ((circleTemplate && !circleTemplate.extendedProperties)
+            || (circleTemplate.extendedProperties
+              && circleTemplate.extendedProperties['meeds.chat.authorized'] === 'true'
+              && circleTemplate.extendedProperties['meeds.chat.enabledByDefault'] === 'true'))
+            && circleTemplate || null;
+          if (this.spaceCircleTemplate) {
+            const subspaceTemplateIds = await this.$spaceTemplateService.getSubspaceTemplateIds() || [];
+            this.isSubspaceTemplate = subspaceTemplateIds.includes(this.spaceCircleTemplate.id);
+          }
         },
       },
       i18n

--- a/webapp/src/main/webapp/vue-apps/user-settings-notifications-extension/extensions.js
+++ b/webapp/src/main/webapp/vue-apps/user-settings-notifications-extension/extensions.js
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-if (matrixUserId) {
+if (typeof matrixUserId !== 'undefined' && matrixUserId) {
   extensionRegistry.registerComponent('UserSettingsNotifications', 'user-settings-notifications-extension', {
     id: 'PushNotificationsSettingsExtension',
     rank: 10,


### PR DESCRIPTION
Merge conditions in the Quick chat creation drawer between the spaces/sub-spaces feature and the Chat administration feature.
Moved the logic of permission management for the room creation to the parent Vue component to be able to use it in multiple drawers.
All the conditions are listed in the related task.